### PR TITLE
Wip hostpapa 18.2.7 skip error low level apple

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6128,6 +6128,7 @@ out:
 
 int Client::may_open(const InodeRef& in, int flags, const UserPerm& perms)
 {
+  std::string str_path;
   ldout(cct, 20) << __func__ << " " << *in << "; " << perms << dendl;
   unsigned want = 0;
 
@@ -6162,6 +6163,12 @@ int Client::may_open(const InodeRef& in, int flags, const UserPerm& perms)
     goto out;
 
   r = inode_permission(in, perms, want);
+  if (r == -CEPHFS_ENOENT || r == CEPHFS_ENOENT) {
+    in->make_path_string(str_path);
+    ldout(cct, 0) << __func__ << "-->inode_permission, "
+                  << "r=" << r << ", str_path=" << str_path << ", "
+                  << cpp_strerror(r) << dendl;
+  }
 out:
   ldout(cct, 3) << __func__ << " " << in << " = " << r <<  dendl;
   return r;
@@ -7898,6 +7905,7 @@ int Client::_getattr(const InodeRef& in, int mask, const UserPerm& perms, bool f
     return 0;
 
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_GETATTR);
+  std::string str_path;
   filepath path;
   in->make_nosnap_relative_path(path);
   req->set_filepath(path);
@@ -7905,6 +7913,13 @@ int Client::_getattr(const InodeRef& in, int mask, const UserPerm& perms, bool f
   req->head.args.getattr.mask = mask;
   
   int res = make_request(req, perms);
+  if (res == -CEPHFS_ENOENT || res == CEPHFS_ENOENT) {
+    in->make_path_string(str_path);
+    ldout(cct, 0) << __func__ << "-->"
+                  << "r=" << res << ", path=" << path
+                  << ", str_path=" << str_path << ", " << cpp_strerror(res)
+                  << dendl;
+  }
   ldout(cct, 10) << __func__ << " result=" << res << dendl;
   return res;
 }
@@ -10230,6 +10245,7 @@ void Client::_put_fh(Fh *f)
 int Client::_open(const InodeRef& in, int flags, mode_t mode, Fh **fhp,
 		  const UserPerm& perms)
 {
+  std::string str_path;
   if (in->snapid != CEPH_NOSNAP &&
       (flags & (O_WRONLY | O_RDWR | O_CREAT | O_TRUNC | O_APPEND))) {
     return -CEPHFS_EROFS;
@@ -10259,6 +10275,11 @@ int Client::_open(const InodeRef& in, int flags, mode_t mode, Fh **fhp,
       ldout(cct, 20) << __func__ << " absolute path: " << path << dendl;
       result = mds_check_access(path, perms, mask);
       if (result) {
+        if (result == -CEPHFS_ENOENT || result == CEPHFS_ENOENT) {
+          ldout(cct, 0) << __func__ << "-->1, "
+                        << "r=" << result << ", path=" << path << ", "
+                        << cpp_strerror(result) << dendl;
+        }
         return result;
       }
       // update wanted?
@@ -10282,6 +10303,13 @@ int Client::_open(const InodeRef& in, int flags, mode_t mode, Fh **fhp,
     req->head.args.open.old_size = in->size;   // for O_TRUNC
     req->set_inode(in);
     result = make_request(req, perms);
+    if (result == -CEPHFS_ENOENT || result == CEPHFS_ENOENT) {
+      in->make_path_string(str_path);
+      ldout(cct, 0) << __func__ << "-->2, "
+                    << "r=" << result << ", path=" << path
+                    << ", str_path=" << str_path << ", " << cpp_strerror(result)
+                    << dendl;
+    }
 
     /*
      * NFS expects that delegations will be broken on a conflicting open,
@@ -10306,6 +10334,13 @@ int Client::_open(const InodeRef& in, int flags, mode_t mode, Fh **fhp,
 	ldout(cct, 8) << "Unable to get caps after open of inode " << *in <<
 			  " . Denying open: " <<
 			  cpp_strerror(result) << dendl;
+        if (result == -CEPHFS_ENOENT || result == CEPHFS_ENOENT) {
+          in->make_path_string(str_path);
+          ldout(cct, 0) << __func__ << "-->3, "
+                        << "r=" << result << ", path=" << path
+                        << ", str_path=" << str_path << ", "
+                        << cpp_strerror(result) << dendl;
+        }
       } else {
 	put_cap_ref(in.get(), need);
       }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -239,6 +239,11 @@ int Client::CommandHook::call(
       m_client->_kick_stale_sessions();
     else if (command == "status")
       m_client->dump_status(f);
+    else if (command == "sync_fs") {
+      m_client->_sync_fs();
+    } else if (command == "trim_cache") {
+      m_client->trim_cache();
+    }
     else
       ceph_abort_msg("bad command registered");
   }
@@ -396,6 +401,11 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
 
   caps_release_delay = cct->_conf.get_val<std::chrono::seconds>(
     "client_caps_release_delay");
+
+  enable_readdir_cache =
+        cct->_conf.get_val<bool>("client_enable_readdir_cache");
+  ldout(cct, 0) << __func__ << ": enable_readdir_cache=" << enable_readdir_cache
+                << dendl;
 
   if (cct->_conf->client_acl_type == "posix_acl")
     acl_type = POSIX_ACL;
@@ -568,6 +578,22 @@ void Client::dump_cache(Formatter *f)
     f->close_section();
 }
 
+void Client::dump_status(char** buf) {
+  std::scoped_lock l{client_lock};
+  JSONFormatter f;
+  f.open_object_section("result");
+  dump_status(&f);
+  f.close_section();
+  std::stringstream ss;
+  f.flush(ss);
+  std::string data = ss.str();
+  *buf = static_cast<char*>(std::malloc(data.size() + 1));
+  if (*buf == nullptr) {
+    return;
+  }
+  std::memcpy(*buf, data.c_str(), data.size() + 1);
+}
+
 void Client::dump_status(Formatter *f)
 {
   ceph_assert(ceph_mutex_is_locked_by_me(client_lock));
@@ -592,6 +618,8 @@ void Client::dump_status(Formatter *f)
     f->dump_stream("inst_str") << inst.name << " " << inst.addr.get_legacy_str();
     f->dump_string("addr_str", inst.addr.get_legacy_str());
     f->dump_int("inode_count", inode_map.size());
+    f->dump_unsigned("inode_ref_openned", inode_ref_openned);
+    f->dump_unsigned("inode_ref_closed", inode_ref_closed);
     f->dump_int("mds_epoch", mdsmap->get_epoch());
     f->dump_int("osd_epoch", osd_epoch);
     f->dump_int("osd_epoch_barrier", cap_epoch_barrier);
@@ -685,6 +713,18 @@ void Client::_finish_init()
   ret = admin_socket->register_command("status",
 				       &m_command_hook,
 				       "show overall client status");
+  if (ret < 0) {
+    lderr(cct) << "error registering admin socket command: "
+	       << cpp_strerror(-ret) << dendl;
+  }
+  ret =
+      admin_socket->register_command("sync_fs", &m_command_hook, "sync the fs");
+  if (ret < 0) {
+    lderr(cct) << "error registering admin socket command: "
+               << cpp_strerror(-ret) << dendl;
+  }
+  ret = admin_socket->register_command("trim_cache", &m_command_hook,
+                                       "trim cache");
   if (ret < 0) {
     lderr(cct) << "error registering admin socket command: "
 	       << cpp_strerror(-ret) << dendl;
@@ -9270,7 +9310,7 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
     return 0;
   }
 
-  vector<DentryRef>::iterator pd = std::lower_bound(dir->readdir_cache.begin(),
+  vector<Dentry*>::iterator pd = std::lower_bound(dir->readdir_cache.begin(),
 						  dir->readdir_cache.end(),
 						  dirp->offset, dentry_off_lt());
 
@@ -9281,7 +9321,7 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
       return -CEPHFS_EAGAIN;
     if (pd == dir->readdir_cache.end())
       break;
-    Dentry *dn = pd->get();
+    Dentry *dn = *pd;
     if (dn->inode == NULL) {
       ldout(cct, 15) << " skipping null '" << dn->name << "'" << dendl;
       ++pd;
@@ -9390,7 +9430,7 @@ int Client::readdir_r_cb(dir_result_t* d,
     want,
     flags,
     getref,
-    false);
+    !enable_readdir_cache);
 }
 
 //
@@ -12490,6 +12530,7 @@ void Client::_ll_get(Inode *in)
 {
   if (in->ll_ref == 0) {
     in->iget();
+    inode_ref_openned++;
     if (in->is_dir() && !in->dentries.empty()) {
       ceph_assert(in->dentries.size() == 1); // dirs can't be hard-linked
       in->get_first_parent()->get(); // pin dentry
@@ -12507,20 +12548,18 @@ int Client::_ll_put(Inode *in, uint64_t num)
   in->ll_put(num);
   ldout(cct, 20) << __func__ << " " << in << " " << in->ino << " " << num << " -> " << in->ll_ref << dendl;
   if (in->ll_ref == 0) {
+    inode_ref_closed++;
+    in->move_to_unpinned();
     if (in->is_dir() && !in->dentries.empty()) {
       ceph_assert(in->dentries.size() == 1); // dirs can't be hard-linked
       in->get_first_parent()->put(); // unpin dentry
     }
-    in->move_to_unpinned();
     if (in->snapid != CEPH_NOSNAP) {
       auto p = ll_snap_ref.find(in->snapid);
       ceph_assert(p != ll_snap_ref.end());
       ceph_assert(p->second > 0);
       if (--p->second == 0)
 	ll_snap_ref.erase(p);
-    }
-    if (in->dir) {
-      in->dir->readdir_cache.clear();
     }
     put_inode(in);
     return 0;
@@ -16386,6 +16425,7 @@ const char** Client::get_tracked_conf_keys() const
     "client_caps_release_delay", \
     "client_deleg_break_on_open", \
     "client_deleg_timeout", \
+    "client_enable_readdir_cache", \
     "client_mount_timeout", \
     "client_oc_max_dirty", \
     "client_oc_max_dirty_age", \
@@ -16458,6 +16498,12 @@ void Client::handle_conf_change(const ConfigProxy& conf,
   if (changed.count("client_mount_timeout")) {
     mount_timeout = cct->_conf.get_val<std::chrono::seconds>(
       "client_mount_timeout");
+  }
+  if (changed.count("client_enable_readdir_cache")) {
+    enable_readdir_cache =
+        cct->_conf.get_val<bool>("client_enable_readdir_cache");
+    ldout(cct, 0) << __func__
+                  << ": enable_readdir_cache=" << enable_readdir_cache << dendl;
   }
 }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -313,6 +313,7 @@ public:
     gid_t gid = group_id >= 0 ? group_id : -1;
     return UserPerm(uid, gid);
   }
+  void dump_status(char** buf);
 
   int mount(const std::string &mount_root, const UserPerm& perms,
 	    bool require_mds=false, const std::string &fs_name="");
@@ -939,6 +940,8 @@ public:
   std::unique_ptr<MDSMap> mdsmap;
 
   bool _collect_and_send_global_metrics;
+  uint64_t inode_ref_openned = 0;
+  uint64_t inode_ref_closed = 0;
 
 protected:
   struct walk_dentry_result {
@@ -1646,6 +1649,7 @@ private:
 
   ceph::coarse_mono_time last_auto_reconnect;
   std::chrono::seconds caps_release_delay, mount_timeout;
+  bool enable_readdir_cache = true;
   // trace generation
   std::ofstream traceout;
 

--- a/src/client/Dir.h
+++ b/src/client/Dir.h
@@ -3,7 +3,6 @@
 
 #include <string>
 #include <vector>
-#include "DentryRef.h"
 
 struct Inode;
 
@@ -13,7 +12,7 @@ class Dir {
   ceph::unordered_map<std::string, Dentry*> dentries;
   unsigned num_null_dentries = 0;
 
-  std::vector<DentryRef> readdir_cache;
+  std::vector<Dentry*> readdir_cache;
 
   explicit Dir(Inode* in) { parent_inode = in; }
 

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -136,7 +136,7 @@ options:
   level: advanced
   desc: take lates snapshot for syncing
   long_desc: take lates snapshot for syncing
-  default: true
+  default: false
   services:
   - cephfs-mirror
 - name: cephfs_mirror_thread_pool_queue_size
@@ -185,7 +185,7 @@ options:
   desc: if this true, mirror daemon will use snapdiff api for snapshot diff
   long_desc: if this true, mirror daemon will use snapdiff api for snapshot diff
       calculation otherwise it will use legacy way of snapshot diff calculation
-  default: false
+  default: true
   services:
   - cephfs-mirror
 - name: cephfs_mirror_lock_directory_before_sync
@@ -230,6 +230,22 @@ options:
   level: advanced
   desc: if this true, mirror daemon will skip the error and keep syncing
   long_desc: if this true, mirror daemon will skip the error and keep syncing
+  default: false
+  services:
+  - cephfs-mirror
+- name: cephfs_mirror_use_low_level_api
+  type: bool
+  level: advanced
+  desc: if this true, mirror daemon will use low level apis
+  long_desc: if this true, mirror daemon will use low level apis
+  default: true
+  services:
+  - cephfs-mirror
+- name: cephfs_mirror_use_at_statx_dont_sync
+  type: bool
+  level: advanced
+  desc: if this true, mirror daemon will use AT_STATX_DONT_SYNC
+  long_desc: if this true, mirror daemon will use AT_STATX_DONT_SYNC
   default: true
   services:
   - cephfs-mirror

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -249,3 +249,14 @@ options:
   default: true
   services:
   - cephfs-mirror
+- name: cephfs_mirror_stat_flush_counter_gap
+  type: uint
+  level: advanced
+  desc: for each thread local stat will be flushed into global stat
+    after counter gap is this
+  long_desc: for each thread local stat will be flushed into global stat
+    after counter gap is this
+  default: 100
+  services:
+  - cephfs-mirror
+  min: 0

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -260,3 +260,27 @@ options:
   services:
   - cephfs-mirror
   min: 0
+- name: cephfs_mirror_turn_off_assert
+  type: bool
+  level: advanced
+  desc: if this true, asserts in PeerReplayer will be turned off
+  long_desc: if this true, asserts in PeerReplayer will be turned off
+  default: false
+  services:
+  - cephfs-mirror
+- name: cephfs_mirror_snap_prefix
+  type: str
+  level: advanced
+  desc: this allows snapshots having specific prefix
+  long_desc: this allows snapshots having specific prefix
+  default: 
+  services:
+  - cephfs-mirror
+- name: cephfs_mirror_sync_from_remote
+  type: bool
+  level: advanced
+  desc: if this true, diff base will be remote
+  long_desc: if this true, diff base will be remote
+  default: false
+  services:
+  - cephfs-mirror

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -318,3 +318,28 @@ options:
   default: false
   services:
   - cephfs-mirror
+- name: cephfs_mirror_round_robin_cost_window
+  type: uint
+  level: advanced
+  desc: this is cost window
+  long_desc: this is cost window 
+  default: 4_M
+  services:
+  - cephfs-mirror
+  min: 1
+- name: cephfs_mirror_round_robin_io_cost
+  type: uint
+  level: advanced
+  desc: this is cost window
+  long_desc: this is cost window 
+  default: 0
+  services:
+  - cephfs-mirror
+- name: cephfs_mirror_apply_drr_balance
+  type: bool
+  level: advanced
+  desc: if this true, drr balance will be applied
+  long_desc: if this true, drr balance will be applied
+  default: false
+  services:
+  - cephfs-mirror

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -284,3 +284,37 @@ options:
   default: false
   services:
   - cephfs-mirror
+- name: cephfs_mirror_enable_local_batching
+  type: bool
+  level: advanced
+  desc: if this true, directory scanning thread will do local batching
+  long_desc: if this true, directory scanning thread will do local batching
+  default: true
+  services:
+  - cephfs-mirror
+- name: cephfs_mirror_local_batch_size
+  type: uint
+  level: advanced
+  desc: local batch size in single thread
+  long_desc: local batch size in single thread
+  default: 10000
+  services:
+  - cephfs-mirror
+  min: 1
+- name: cephfs_mirror_file_queue_size
+  type: uint
+  level: advanced
+  desc: number of file transfer request in a queue
+  long_desc: number of file transfer request in a queue
+  default: 100000
+  services:
+  - cephfs-mirror
+  min: 1
+- name: cephfs_mirror_reset_inode_before_submission
+  type: bool
+  level: advanced
+  desc: if this true, file inode will be reset before submission
+  long_desc: if this true, file inode will be reset before submission
+  default: false
+  services:
+  - cephfs-mirror

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -589,3 +589,11 @@ options:
   - mds_client
   flags:
   - runtime
+- name: client_enable_readdir_cache
+  type: bool
+  level: advanced
+  desc: if this true, client readdir cache will be enabled
+  long_desc: if this true, client readdir cache will be enabled
+  default: true
+  services:
+  - mds_client

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -2201,6 +2201,8 @@ int ceph_get_snap_info(struct ceph_mount_info *cmount,
  * @param snap_info snapshot info struct (fetched via call to ceph_get_snap_info()).
  */
 void ceph_free_snap_info_buffer(struct snap_info *snap_info);
+
+int ceph_client_status(struct ceph_mount_info *cmount, char** buf);
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -2029,6 +2029,13 @@ int ceph_ll_setlk(struct ceph_mount_info *cmount,
 
 int ceph_ll_lazyio(struct ceph_mount_info *cmount, Fh *fh, int enable);
 
+int ceph_ll_open_snapdiff(
+    struct ceph_mount_info* cmount,
+    Inode* in1,
+    Inode* in2,
+    struct ceph_snapdiff_info* out,
+    const UserPerm* perms);
+
 /*
  * Delegation support
  *

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2236,6 +2236,39 @@ extern "C" uint64_t ceph_ll_get_internal_offset(class ceph_mount_info *cmount,
   return (cmount->get_client()->ll_get_internal_offset(in, blockno));
 }
 
+extern "C" int
+ceph_ll_open_snapdiff(
+    struct ceph_mount_info* cmount,
+    Inode* in1,
+    Inode* in2,
+    struct ceph_snapdiff_info* out,
+    const UserPerm* perms)
+{
+  if (!cmount->is_mounted()) {
+    errno = ENOTCONN;
+    return -errno;
+  }
+  if (!out || !in1 || !in2 || in1->snapid == CEPH_NOSNAP ||
+      in2->snapid == CEPH_NOSNAP) {
+    errno = EINVAL;
+    return -errno;
+  }
+  out->cmount = cmount;
+  out->dir1 = out->dir_aux = nullptr;
+  int r = ceph_ll_opendir(cmount, in1, &(out->dir1), perms);
+  if (r != 0) {
+    errno = ENOENT;
+    return -errno;
+  }
+  r = ceph_ll_opendir(cmount, in2, &(out->dir_aux), perms);
+  if (r != 0) {
+    ceph_close_snapdiff(out);
+    errno = ENOENT;
+    return -errno;
+  }
+  return 0;
+}
+
 extern "C" void ceph_buffer_free(char *buf)
 {
   if (buf) {

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2385,3 +2385,12 @@ extern "C" void ceph_free_snap_info_buffer(struct snap_info *snap_info) {
   }
   free(snap_info->snap_metadata);
 }
+
+extern "C" int ceph_client_status(struct ceph_mount_info *cmount, char** buf) {
+  if (!cmount->is_mounted()) {
+    /* we set errno to signal errors. */
+    return -ENOTCONN;
+  }
+  cmount->get_client()->dump_status(buf);
+  return 0;
+}

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -11621,7 +11621,7 @@ void Server::handle_client_readdir_snapdiff(MDRequestRef& mdr)
   unsigned max_bytes = req->head.args.snapdiff.max_bytes;
   if (!max_bytes)
     // make sure at least one item can be encoded
-    max_bytes = (512 << 10) + mds->mdsmap->get_max_xattr_size();
+    max_bytes = ((512 << 10) + mds->mdsmap->get_max_xattr_size()) << 1;
 
   // start final blob
   bufferlist dirbl;
@@ -11710,88 +11710,58 @@ void Server::_readdir_diff(
   bool from_the_beginning = !offset_hash && offset_str.empty();
   // skip all dns <= dentry_key_t(*, offset_str, offset_hash)
   dentry_key_t skip_key(CEPH_NOSNAP, offset_str.c_str(), offset_hash);
-
-  // We need to rollback all the entries with the same name
-  // when some entries with this name don't fit into the same fragment.
-  // This is caused by the limited ability for offset provisioning between
-  // fragments - there is no way to identify specific snapshot for the last entry.
-  // The following vars denote the potential rollback position for such a case.
-  // Fixes: https://tracker.ceph.com/issues/72518
-  string last_name;
-  size_t rollback_pos = 0;
-  size_t rollback_num = 0;
+  bool retry = false;
 
   bool end = build_snap_diff(
-    mdr,
-    dir,
-    bytes_left,
-    from_the_beginning ? nullptr : & skip_key,
-    snapid_prev,
-    snapid,
-    dnbl,
-    [&](CDentry* dn, CInode* in, bool exists) {
-      string name;
-      snapid_t effective_snapid;
-      const auto& dn_name = dn->get_name();
-      // provide the first snapid for removed entries and
-      // the last one for existent ones
-      effective_snapid = exists ? snapid : snapid_prev;
-      name.append(dn_name);
-      if ((int)(dnbl.length() + name.length() + sizeof(__u32) + sizeof(LeaseStat)) > bytes_left) {
-	dout(10) << " ran out of room for name, stopping at " << dnbl.length() << " < " << bytes_left << dendl;
-        if (name == last_name) {
-	  bufferlist keep;
-	  keep.substr_of(dnbl, 0, rollback_pos);
-	  dnbl.swap(keep);
-          last_name.clear();
-          rollback_pos = 0;
-          numfiles = rollback_num;
-          rollback_num = 0;
+      mdr, dir, bytes_left, from_the_beginning ? nullptr : &skip_key,
+      snapid_prev, snapid, dnbl, &retry,
+      [&](const std::vector<SnapdiffEntryInfo> &dn_vec) {
+        uint64_t least_room_needed = 0;
+        for (const auto &entry_info : dn_vec) {
+          least_room_needed += (entry_info.dn->get_name().length() +
+                                sizeof(__u32) + sizeof(LeaseStat));
         }
-	return false;
-      }
+        if (dnbl.length() + least_room_needed > (uint64_t)bytes_left) {
+          dout(10) << " ran out of room for name, stopping at " << dnbl.length()
+                   << " < " << bytes_left << dendl;
+          return false;
+        }
+        for (const auto &entry_info : dn_vec) {
+          auto dn = entry_info.dn;
+          auto in = entry_info.in;
+          auto exists = entry_info.exists;
+          string name;
+          snapid_t effective_snapid;
+          const auto &dn_name = dn->get_name();
+          // provide the first snapid for removed entries and
+          // the last one for existent ones
+          effective_snapid = exists ? snapid : snapid_prev;
+          name.append(dn_name);
+          auto diri = dir->get_inode();
+          auto hash = ceph_frag_value(diri->hash_dentry_name(dn_name));
+          dout(10) << "inc dn " << *dn << " as " << name << std::hex
+                   << " hash 0x" << hash << std::dec << " " << effective_snapid
+                   << dendl;
+          encode(name, dnbl);
+          mds->locker->issue_client_lease(dn, in, mdr, now, dnbl);
 
-      auto diri = dir->get_inode();
-      auto hash = ceph_frag_value(diri->hash_dentry_name(dn_name));
-      unsigned start_len = dnbl.length();
-      dout(10) << "inc dn " << *dn << " as " << name
-               << std::hex << " hash 0x" << hash << std::dec
-               << " " << effective_snapid
-               << dendl;
-      encode(name, dnbl);
-      mds->locker->issue_client_lease(dn, in, mdr, now, dnbl);
+          // inode
+          dout(10) << "inc inode " << *in << " snap " << effective_snapid
+                   << dendl;
 
-      // inode
-      dout(10) << "inc inode " << *in << " snap "	<< effective_snapid << dendl;
-      int r = in->encode_inodestat(dnbl, mdr->session, realm, effective_snapid, bytes_left - (int)dnbl.length());
-      if (r < 0) {
-	// chop off dn->name, lease
-	dout(10) << " ran out of room, stopping at "
-	         << start_len << " < " << bytes_left << dendl;
-	bufferlist keep;
-
-	keep.substr_of(dnbl, 0,
-          name == last_name ? rollback_pos : start_len);
-	dnbl.swap(keep);
-
-        last_name.clear();
-        rollback_pos = 0;
-        numfiles = rollback_num;
-        rollback_num = 0;
-	return false;
-      }
-
-      // set rollback position
-      if (name != last_name) {
-        last_name = name;
-        rollback_pos = start_len;
-        rollback_num = numfiles;
-      }
-      // touch dn
-      mdcache->lru.lru_touch(dn);
-      ++numfiles;
-      return true;
-    });
+          // I know I am breaking rules of byte limit, but just adding at most
+          // two entries to get rid of rollback complexity in attempted fix:
+          // https://tracker.ceph.com/issues/72518
+          in->encode_inodestat(dnbl, mdr->session, realm, effective_snapid);
+          // touch dn
+          mdcache->lru.lru_touch(dn);
+          ++numfiles;
+        }
+        return true;
+      });
+  if (retry) {
+    return;
+  }
 
   __u16 flags = 0;
   if (req_flags & CEPH_READDIR_REPLY_BITFLAGS) {
@@ -11812,26 +11782,54 @@ bool Server::build_snap_diff(
   snapid_t snapid_prev,
   snapid_t snapid,
   const bufferlist& dnbl,
-  std::function<bool (CDentry*, CInode*, bool)> add_result_cb)
+  bool *retry,
+  std::function<bool(const std::vector<SnapdiffEntryInfo> &)>
+        add_result_cb)
 {
+  assert(retry);
   client_t client = mdr->client_request->get_source().num();
+  SnapdiffEntryInfo before;
 
-  struct EntryInfo {
-    CDentry* dn = nullptr;
-    CInode* in = nullptr;
-    utime_t mtime;
-
-    void reset() {
-      *this = EntryInfo();
+  auto insert_current = [&](SnapdiffEntryInfo &current,
+                            bool ignore_prev = false) {
+    if (before.dn) {
+      if (!ignore_prev) {
+        ceph_assert(before.dn->get_name() != current.dn->get_name());
+      } else {
+        ceph_assert(before.dn->get_name() == current.dn->get_name());
+      }
+      if (!ignore_prev && !add_result_cb({before})) {
+        return false;
+      }
+      before.reset();
     }
-  } before;
+    if (!add_result_cb({current})) {
+      return false;
+    }
+    return true;
+  };
 
-  auto insert_deleted = [&](EntryInfo& ei) {
-    dout(20) << "build_snap_diff deleted file " << ei.dn->get_name() << " "
-      << ei.dn->first << "/" << ei.dn->last << dendl;
-    int r = add_result_cb(ei.dn, ei.in, false);
-    ei.reset();
-    return r;
+  auto insert_before = [&](SnapdiffEntryInfo& current) {
+    if (before.dn) {
+      ceph_assert(before.dn->get_name() != current.dn->get_name());
+      if (!add_result_cb({before})) {
+        return false;
+      }
+      before.reset();
+    }
+    before = current;
+    before.exists = false;
+    return true;
+  };
+
+  auto insert_both = [&](SnapdiffEntryInfo& current) {
+    ceph_assert(before.dn);
+    ceph_assert(before.dn->get_name() == current.dn->get_name());
+    if (!add_result_cb({before, current})) {
+      return false;
+    }
+    before.reset();
+    return true;
   };
 
   auto it = !skip_key ? dir->begin() : dir->upper_bound(*skip_key);
@@ -11886,6 +11884,7 @@ bool Server::build_snap_diff(
 	  mds->locker->drop_locks(mdr.get());
 	  mdr->drop_local_auth_pins();
 	  mdcache->open_remote_dentry(dn, dnp, new C_MDS_RetryRequest(mdcache, mdr));
+    *retry = true;
 	}
 	return false;
       }
@@ -11893,94 +11892,45 @@ bool Server::build_snap_diff(
     ceph_assert(in);
 
     utime_t mtime = in->get_inode()->mtime;
-    if (in->is_dir()) {
-
-      // we need to maintain the order of entries (determined by their name hashes)
-      // hence need to insert the previous entry if any immediately.
-      if (before.dn) {
-	if (!insert_deleted(before)) {
-	  break;
-	}
+    SnapdiffEntryInfo current{dn, in, true, mtime};
+    if (dn->first > snapid_prev && dn->last < snapid) {
+      continue;
+    } else if (dn->first <= snapid_prev && dn->last >= snapid) {
+      if (in->is_dir()) {
+        if (!insert_current(current)) {
+          return false;
+        }
       }
-
-      bool exists = true;
-      if (snapid_prev < dn->first && dn->last < snapid) {
-	dout(20) << __func__ << " skipping inner " << dn->get_name() << " "
-	  << dn->first << "/" << dn->last << dendl;
-	continue;
-      } else if (dn->first <= snapid_prev && dn->last < snapid) {
-	// dir deleted
-	dout(20) << __func__ << " deleted dir " << dn->get_name() << " "
-	  << dn->first << "/" << dn->last << dendl;
-	exists = false;
-      }
-      bool r = add_result_cb(dn, in, exists);
-      if (!r) {
-	break;
+    } else if (dn->first <= snapid_prev && dn->last < snapid) {
+      if (!insert_before(current)) {
+        return false;
       }
     } else {
-      if (snapid_prev >= dn->first && snapid <= dn->last) {
-	dout(20) << __func__ << " skipping unchanged " << dn->get_name() << " "
-	  << dn->first << "/" << dn->last << dendl;
-	continue;
-      } else if (snapid_prev < dn->first && snapid > dn->last) {
-	dout(20) << __func__ << " skipping inner modification " << dn->get_name() << " "
-	  << dn->first << "/" << dn->last << dendl;
-	continue;
-      }
+      ceph_assert(dn->first > snapid_prev && dn->last >= snapid);
       string_view name_before =
-        before.dn ? string_view(before.dn->get_name()) : string_view();
-      if (before.dn && dn->get_name() != name_before) {
-        if (!insert_deleted(before)) {
-          break;
+          before.dn ? string_view(before.dn->get_name()) : string_view();
+      if (name_before != dn->get_name()) {
+        if (!insert_current(current)) {
+          return false;
         }
-        before.reset();
-      }
-      if (snapid_prev >= dn->first && snapid_prev <= dn->last) {
-	dout(30) << __func__ << " dn_before " << dn->get_name() << " "
-	  << dn->first << "/" << dn->last << dendl;
-	before = EntryInfo {dn, in, mtime};
-	continue;
+      } else if (before.in->is_dir() || in->is_dir() ||
+          before.in->ino() != in->ino()) {
+        if (!insert_both(current)) {
+          return false;
+        }
+      } else if (before.mtime != mtime) {
+        if (!insert_current(current, true)) {
+          return false;
+        }
       } else {
-	if (before.dn && dn->get_name() == name_before) {
-	  if (before.in->ino() != in->ino()) {
-	    dout(30) << __func__ << " inode changed " << dn->get_name() << " "
-		     << dn->first << "/" << dn->last
-		     << " " << before.mtime << " vs. " << mtime
-		     << dendl;
-	    if (!insert_deleted(before)) {
-	      break;
-	    }
-	    before.reset();
-	  } else {
-	    if (mtime == before.mtime) {
-	      dout(30) << __func__ << " timestamp not changed " << dn->get_name() << " "
-		       << dn->first << "/" << dn->last
-		       << " " << mtime
-		       << dendl;
-	      before.reset();
-	      continue;
-	    } else {
-	      dout(30) << __func__ << " timestamp changed " << dn->get_name() << " "
-		       << dn->first << "/" << dn->last
-		       << " " << before.mtime << " vs. " << mtime
-		       << dendl;
-	      before.reset();
-	    }
-	  }
-	}
-	dout(20) << __func__ << " new file " << dn->get_name() << " "
-	  << dn->first << "/" << dn->last
-	  << dendl;
-	ceph_assert(snapid >= dn->first && snapid <= dn->last);
-      }
-      if (!add_result_cb(dn, in, true)) {
-	break;
+        before.reset();
       }
     }
   }
   if (before.dn) {
-    insert_deleted(before);
+    if (!add_result_cb({before})) {
+      return false;
+    }
   }
-  return it == dir->end();
+  return true;
 }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -11943,19 +11943,30 @@ bool Server::build_snap_diff(
 	continue;
       } else {
 	if (before.dn && dn->get_name() == name_before) {
-	  if (mtime == before.mtime) {
-	    dout(30) << __func__ << " timestamp not changed " << dn->get_name() << " "
-	      << dn->first << "/" << dn->last
-	      << " " << mtime
-	      << dendl;
+	  if (before.in->ino() != in->ino()) {
+	    dout(30) << __func__ << " inode changed " << dn->get_name() << " "
+		     << dn->first << "/" << dn->last
+		     << " " << before.mtime << " vs. " << mtime
+		     << dendl;
+	    if (!insert_deleted(before)) {
+	      break;
+	    }
 	    before.reset();
-	    continue;
 	  } else {
-	    dout(30) << __func__ << " timestamp changed " << dn->get_name() << " "
-	      << dn->first << "/" << dn->last
-	      << " " << before.mtime << " vs. " << mtime
-	      << dendl;
-	    before.reset();
+	    if (mtime == before.mtime) {
+	      dout(30) << __func__ << " timestamp not changed " << dn->get_name() << " "
+		       << dn->first << "/" << dn->last
+		       << " " << mtime
+		       << dendl;
+	      before.reset();
+	      continue;
+	    } else {
+	      dout(30) << __func__ << " timestamp changed " << dn->get_name() << " "
+		       << dn->first << "/" << dn->last
+		       << " " << before.mtime << " vs. " << mtime
+		       << dendl;
+	      before.reset();
+	    }
 	  }
 	}
 	dout(20) << __func__ << " new file " << dn->get_name() << " "

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -510,6 +510,16 @@ private:
     uint32_t offset_hash,
     unsigned req_flags,
     bufferlist& dirbl);
+  struct SnapdiffEntryInfo {
+    CDentry* dn = nullptr;
+    CInode* in = nullptr;
+    bool exists = false;
+    utime_t mtime;
+
+    void reset() {
+      *this = SnapdiffEntryInfo();
+    }
+  };
   bool build_snap_diff(
     MDRequestRef& mdr,
     CDir* dir,
@@ -518,7 +528,9 @@ private:
     snapid_t snapid_before,
     snapid_t snapid,
     const bufferlist& dnbl,
-    std::function<bool(CDentry*, CInode*, bool)> add_result_cb);
+    bool *retry,
+    std::function<bool(const std::vector<SnapdiffEntryInfo> &)>
+        add_result_cb);
 
   MDSRank *mds;
   MDCache *mdcache;

--- a/src/pybind/mgr/mirroring/fs/dir_map/policy.py
+++ b/src/pybind/mgr/mirroring/fs/dir_map/policy.py
@@ -11,6 +11,80 @@ from ..exception import MirrorException
 
 log = logging.getLogger(__name__)
 
+class GlobalDirectoryBalancer:
+    def __init__(self):
+        self.lock = Lock()
+        self.dir_owners = {}  # type: Dict[str, str]
+        self.daemon_dir_counts = {}  # type: Dict[str, int]
+
+    @staticmethod
+    def dir_key(fs_name, dir_path):
+        return f'{fs_name}:{dir_path}'
+
+    def _inc(self, daemon_id):
+        self.daemon_dir_counts[daemon_id] = self.daemon_dir_counts.get(daemon_id, 0) + 1
+
+    def _dec(self, daemon_id):
+        if not daemon_id:
+            return
+        count = self.daemon_dir_counts.get(daemon_id, 0)
+        if count <= 1:
+            self.daemon_dir_counts.pop(daemon_id, None)
+        else:
+            self.daemon_dir_counts[daemon_id] = count - 1
+
+    def register_mapping(self, fs_name, dir_path, daemon_id):
+        if not daemon_id:
+            return
+        with self.lock:
+            self.register_mapping_locked(fs_name, dir_path, daemon_id)
+
+    def register_mapping_locked(self, fs_name, dir_path, daemon_id):
+        key = GlobalDirectoryBalancer.dir_key(fs_name, dir_path)
+        old_daemon_id = self.dir_owners.get(key)
+        if old_daemon_id == daemon_id:
+            return
+        self._dec(old_daemon_id)
+        self.dir_owners[key] = daemon_id
+        self._inc(daemon_id)
+
+    def unregister_mapping(self, fs_name, dir_path):
+        with self.lock:
+            self.unregister_mapping_locked(fs_name, dir_path)
+
+    def unregister_mapping_locked(self, fs_name, dir_path):
+        key = GlobalDirectoryBalancer.dir_key(fs_name, dir_path)
+        old_daemon_id = self.dir_owners.pop(key, None)
+        self._dec(old_daemon_id)
+
+    def choose_instance(self, instance_to_daemon, instance_to_dir_count):
+        with self.lock:
+            return self.choose_instance_locked(instance_to_daemon, instance_to_dir_count)
+
+    def choose_instance_locked(self, instance_to_daemon, instance_to_dir_count):
+        min_instance_id = None
+        min_global_count = None
+        min_local_count = None
+        for instance_id in sorted(instance_to_daemon.keys()):
+            daemon_id = instance_to_daemon[instance_id]
+            global_count = self.daemon_dir_counts.get(daemon_id, 0)
+            local_count = instance_to_dir_count.get(instance_id, 0)
+            if min_instance_id is None or \
+               global_count < min_global_count or \
+               (global_count == min_global_count and local_count < min_local_count):
+                min_instance_id = instance_id
+                min_global_count = global_count
+                min_local_count = local_count
+        return min_instance_id
+
+    def remove_filesystem(self, fs_name):
+        with self.lock:
+            prefix = f'{fs_name}:'
+            for key in list(self.dir_owners.keys()):
+                if key.startswith(prefix):
+                    old_daemon_id = self.dir_owners.pop(key)
+                    self._dec(old_daemon_id)
+
 class DirectoryState:
     def __init__(self, instance_id=None, mapped_time=None):
         self.instance_id = instance_id
@@ -31,11 +105,15 @@ class Policy:
     # to other mirror daemon instances.
     DIR_SHUFFLE_THROTTLE_INTERVAL = 300
 
-    def __init__(self):
+    def __init__(self, fs_name=None, global_dir_balancer=None):
         self.dir_states = {}
         self.instance_to_dir_map = {}
+        self.instance_to_daemon = {}
         self.dead_instances = []
         self.lock = Lock()
+        self.fs_name = fs_name
+        self.global_dir_balancer = global_dir_balancer
+
 
     @staticmethod
     def is_instance_action(action_type):
@@ -83,6 +161,9 @@ class Policy:
                     self.instance_to_dir_map[instance_id].append(dir_path)
                 self.dir_states[dir_path] = DirectoryState(instance_id, dir_map['last_shuffled'])
                 dir_state = self.dir_states[dir_path]
+                if self.global_dir_balancer:
+                    daemon_id = self.instance_to_daemon.get(instance_id, instance_id)
+                    self.global_dir_balancer.register_mapping(self.fs_name, dir_path, daemon_id)
                 state = State.INITIALIZING if instance_id else State.ASSOCIATING
                 purging = dir_map.get('purging', 0)
                 if purging:
@@ -108,34 +189,50 @@ class Policy:
     def map(self, dir_path, dir_state):
         log.debug(f'mapping {dir_path}')
         min_instance_id = None
-        current_instance_id = dir_state.instance_id
-        if current_instance_id and not self.is_dead_instance(current_instance_id):
+        assert self.global_dir_balancer is not None
+        with self.global_dir_balancer.lock:
+            current_instance_id = dir_state.instance_id
+            if current_instance_id and not self.is_dead_instance(current_instance_id):
+                return True
+            if self.is_dead_instance(current_instance_id):
+                self.unmap_locked(dir_path, dir_state)
+            instance_to_daemon = {}
+            instance_to_dir_count = {}
+            for instance_id in self.instance_to_dir_map.keys():
+                if self.is_dead_instance(instance_id):
+                    continue
+                instance_to_daemon[instance_id] = self.instance_to_daemon.get(instance_id, instance_id)
+                instance_to_dir_count[instance_id] = len(self.instance_to_dir_map[instance_id])
+            min_instance_id = self.global_dir_balancer.choose_instance_locked(instance_to_daemon,
+                                                                               instance_to_dir_count)
+            if not min_instance_id:
+                log.debug(f'instance unavailable for {dir_path}')
+                return False
+            log.debug(f'dir_path {dir_path} maps to instance {min_instance_id}')
+            dir_state.instance_id = min_instance_id
+            dir_state.mapped_time = time.time()
+            self.instance_to_dir_map[min_instance_id].append(dir_path)
+            daemon_id = self.instance_to_daemon.get(min_instance_id, min_instance_id)
+            self.global_dir_balancer.register_mapping_locked(self.fs_name, dir_path, daemon_id)
             return True
-        if self.is_dead_instance(current_instance_id):
-            self.unmap(dir_path, dir_state)
-        for instance_id, dir_paths in self.instance_to_dir_map.items():
-            if self.is_dead_instance(instance_id):
-                continue
-            if not min_instance_id or len(dir_paths) < len(self.instance_to_dir_map[min_instance_id]):
-                min_instance_id = instance_id
-        if not min_instance_id:
-            log.debug(f'instance unavailable for {dir_path}')
-            return False
-        log.debug(f'dir_path {dir_path} maps to instance {min_instance_id}')
-        dir_state.instance_id = min_instance_id
-        dir_state.mapped_time = time.time()
-        self.instance_to_dir_map[min_instance_id].append(dir_path)
-        return True
 
-    def unmap(self, dir_path, dir_state):
+    def unmap_locked(self, dir_path, dir_state):
         instance_id = dir_state.instance_id
         log.debug(f'unmapping {dir_path} from instance {instance_id}')
         self.instance_to_dir_map[instance_id].remove(dir_path)
+        if self.global_dir_balancer:
+            self.global_dir_balancer.unregister_mapping_locked(self.fs_name, dir_path)
         dir_state.instance_id = None
         dir_state.mapped_time = None
         if self.is_dead_instance(instance_id) and not self.instance_to_dir_map[instance_id]:
             self.instance_to_dir_map.pop(instance_id)
+            self.instance_to_daemon.pop(instance_id, None)
             self.dead_instances.remove(instance_id)
+
+    def unmap(self, dir_path, dir_state):
+        assert self.global_dir_balancer is not None
+        with self.global_dir_balancer.lock:
+            self.unmap_locked(dir_path, dir_state)
 
     def shuffle(self, dirs_per_instance, include_stalled_dirs):
         log.debug(f'directories per instance: {dirs_per_instance}')
@@ -265,27 +362,40 @@ class Policy:
             log.debug(f'dir_state: {dir_state}')
             return r
 
-    def add_instances_initial(self, instance_ids):
+    def add_instances_initial(self, instances):
         """Take care of figuring out instances which no longer exist
         and remove them. This is to be done only once on startup to
         identify instances which were previously removed but directories
         are still mapped (on-disk) to them.
         """
-        for instance_id in instance_ids:
+        for instance_id, daemon_id in instances.items():
             if not instance_id in self.instance_to_dir_map:
                 self.instance_to_dir_map[instance_id] = []
+            self._update_instance_daemon(instance_id, daemon_id)
         dead_instances = []
         for instance_id, _ in self.instance_to_dir_map.items():
-            if not instance_id in instance_ids:
+            if not instance_id in instances:
                 dead_instances.append(instance_id)
         if dead_instances:
             self._remove_instances(dead_instances)
 
-    def add_instances(self, instance_ids, initial_update=False):
-        log.debug(f'adding instances: {instance_ids} initial_update {initial_update}')
+    def _update_instance_daemon(self, instance_id, daemon_id):
+        old_daemon_id = self.instance_to_daemon.get(instance_id)
+        if old_daemon_id == daemon_id:
+            return
+        self.instance_to_daemon[instance_id] = daemon_id
+        if not old_daemon_id:
+            return
+        if self.global_dir_balancer:
+            for dir_path in self.instance_to_dir_map.get(instance_id, []):
+                self.global_dir_balancer.unregister_mapping(self.fs_name, dir_path)
+                self.global_dir_balancer.register_mapping(self.fs_name, dir_path, daemon_id)
+
+    def add_instances(self, instances, initial_update=False):
+        log.debug(f'adding instances: {instances} initial_update {initial_update}')
         with self.lock:
             if initial_update:
-                self.add_instances_initial(instance_ids)
+                self.add_instances_initial(instances)
             else:
                 nr_instances = len(self.instance_to_dir_map)
                 nr_dead_instances = len(self.dead_instances)
@@ -293,9 +403,10 @@ class Policy:
                     # adjust dead instances
                     nr_instances -= nr_dead_instances
                 include_stalled_dirs = nr_instances == 0
-                for instance_id in instance_ids:
+                for instance_id, daemon_id in instances.items():
                     if not instance_id in self.instance_to_dir_map:
                         self.instance_to_dir_map[instance_id] = []
+                    self._update_instance_daemon(instance_id, daemon_id)
                 dirs_per_instance = int(len(self.dir_states) /
                                         (len(self.instance_to_dir_map) - nr_dead_instances))
                 if dirs_per_instance == 0:
@@ -326,6 +437,7 @@ class Policy:
                 continue
             if not self.instance_to_dir_map[instance_id]:
                 self.instance_to_dir_map.pop(instance_id)
+                self.instance_to_daemon.pop(instance_id, None)
                 continue
             self.dead_instances.append(instance_id)
             dir_paths = self.instance_to_dir_map[instance_id]
@@ -376,5 +488,9 @@ class Policy:
                 'mapping': {}
             } # type: Dict
             for instance_id, dir_paths in self.instance_to_dir_map.items():
-                res['mapping'][instance_id] = f'{len(dir_paths)} directories'
+                daemon_id = self.instance_to_daemon.get(instance_id, instance_id)
+                res['mapping'][instance_id] = {
+                    'daemon_id': daemon_id,
+                    'directory_count': len(dir_paths)
+                }
             return res

--- a/src/pybind/mgr/mirroring/fs/notify.py
+++ b/src/pybind/mgr/mirroring/fs/notify.py
@@ -49,7 +49,9 @@ class InstanceWatcher:
         self.listener = listener
         self.instances = {}
         for instance_id, data in instances.items():
+            daemon_id = data.get('daemon_id', instance_id)
             self.instances[instance_id] = {'addr': data['addr'],
+                                           'daemon_id': daemon_id,
                                            'seen': time.time()}
         self.lock = threading.Lock()
         self.cond = threading.Condition(self.lock)
@@ -86,10 +88,20 @@ class InstanceWatcher:
                     # sender data is quoted
                     notifier_data = json.loads(ack[2].decode('utf-8'))
                     log.debug(f'InstanceWatcher.handle_notify: {instance_id}: {notifier_data}')
+                    daemon_id = notifier_data.get('daemon_id', instance_id)
+                    addr = notifier_data['addr']
                     if not instance_id in self.instances:
                         self.instances[instance_id] = {}
-                        added[instance_id] = notifier_data['addr']
-                    self.instances[instance_id]['addr'] = notifier_data['addr']
+                        added[instance_id] = {'addr': addr,
+                                              'daemon_id': daemon_id}
+                    else:
+                        current_daemon_id = self.instances[instance_id].get('daemon_id', instance_id)
+                        current_addr = self.instances[instance_id].get('addr')
+                        if current_daemon_id != daemon_id or current_addr != addr:
+                            added[instance_id] = {'addr': addr,
+                                                  'daemon_id': daemon_id}
+                    self.instances[instance_id]['addr'] = addr
+                    self.instances[instance_id]['daemon_id'] = daemon_id
                     self.instances[instance_id]['seen'] = time.time()
                 # gather non responders
                 now = time.time()

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -24,7 +24,7 @@ from .exception import MirrorException
 from .dir_map.create import create_mirror_object
 from .dir_map.load import load_dir_map, load_instances
 from .dir_map.update import UpdateDirMapRequest, UpdateInstanceRequest
-from .dir_map.policy import Policy
+from .dir_map.policy import Policy, GlobalDirectoryBalancer
 from .dir_map.state_transition import ActionType
 
 log = logging.getLogger(__name__)
@@ -39,11 +39,11 @@ class FSPolicy:
         def handle_instances(self, added, removed):
             self.fspolicy.update_instances(added, removed)
 
-    def __init__(self, mgr, ioctx):
+    def __init__(self, mgr, ioctx, filesystem, global_dir_balancer):
         self.mgr = mgr
         self.ioctx = ioctx
         self.pending = []
-        self.policy = Policy()
+        self.policy = Policy(filesystem, global_dir_balancer)
         self.lock = threading.Lock()
         self.cond = threading.Condition(self.lock)
         self.dir_paths = []
@@ -66,7 +66,10 @@ class FSPolicy:
             self.policy.init(dir_mapping)
             # we'll schedule action for all directories, so don't bother capturing
             # directory names here.
-            self.policy.add_instances(list(instances.keys()), initial_update=True)
+            instance_daemons = {}
+            for instance_id, data in instances.items():
+                instance_daemons[instance_id] = data.get('daemon_id', instance_id)
+            self.policy.add_instances(instance_daemons, initial_update=True)
             self.instance_watcher = InstanceWatcher(self.ioctx, instances,
                                                     self.instance_listener)
             self.schedule_action(list(dir_mapping.keys()))
@@ -104,10 +107,13 @@ class FSPolicy:
                     log.debug(f'handle_update_instances: policy shutting down')
                     return
                 schedules = []
+                instance_daemons = {}
+                for instance_id, data in instances_added.items():
+                    instance_daemons[instance_id] = data.get('daemon_id', instance_id)
                 if instances_removed:
                     schedules.extend(self.policy.remove_instances(instances_removed))
-                if instances_added:
-                    schedules.extend(self.policy.add_instances(instances_added))
+                if instance_daemons:
+                    schedules.extend(self.policy.add_instances(instance_daemons))
                 self.schedule_action(schedules)
             finally:
                 self.op_tracker.finish_async_op()
@@ -132,13 +138,16 @@ class FSPolicy:
         with self.lock:
             instances_added = {}
             instances_removed = []
-            for instance_id, addr in added.items():
-                instances_added[instance_id] = {'version': 1, 'addr': addr}
+            for instance_id, data in added.items():
+                daemon_id = data.get('daemon_id', instance_id)
+                instances_added[instance_id] = {'version': 1,
+                                                'addr': data['addr'],
+                                                'daemon_id': daemon_id}
             instances_removed = list(removed.keys())
             request_id = str(uuid.uuid4())
             def async_callback(r):
                 self.finisher.queue(self.handle_update_instances,
-                                    [list(instances_added.keys()), instances_removed, request_id, r])
+                                    [instances_added.copy(), instances_removed, request_id, r])
             # blacklisted instances can be removed at this point. remapping directories
             # mapped to blacklisted instances on module startup is handled in policy
             # add_instances().
@@ -284,6 +293,7 @@ class FSSnapshotMirror:
         self.mgr = mgr
         self.rados = mgr.rados
         self.pool_policy = {}
+        self.global_dir_balancer = GlobalDirectoryBalancer()
         self.fs_map = self.mgr.get('fs_map')
         self.lock = threading.Lock()
         self.refresh_pool_policy()
@@ -489,7 +499,7 @@ class FSSnapshotMirror:
             dir_mapping = load_dir_map(ioctx)
             instances = load_instances(ioctx)
             # init policy
-            fspolicy = FSPolicy(self.mgr, ioctx)
+            fspolicy = FSPolicy(self.mgr, ioctx, filesystem, self.global_dir_balancer)
             log.debug(f'init policy for filesystem {filesystem}: pool-id {metadata_pool_id}')
             fspolicy.init(dir_mapping, instances)
             self.pool_policy[filesystem] = fspolicy
@@ -505,6 +515,7 @@ class FSSnapshotMirror:
                 log.info(f'shutdown pool policy for {filesystem}')
                 fspolicy = self.pool_policy.pop(filesystem)
                 fspolicy.shutdown()
+                self.global_dir_balancer.remove_filesystem(filesystem)
         for filesystem in filesystems:
             if not filesystem in self.pool_policy:
                 log.info(f'init pool policy for {filesystem}')

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -168,6 +168,10 @@ FSMirror::~FSMirror() {
   }
 }
 
+std::string FSMirror::get_daemon_id() {
+  return m_service_daemon->get_instance_id();
+}
+
 int FSMirror::init_replayer(PeerReplayer *peer_replayer) {
   ceph_assert(ceph_mutex_is_locked(m_lock));
   return peer_replayer->init();

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -94,7 +94,7 @@ public:
     if (r == 0) {
       commands[cmd] = new StatusCommand(fs_mirror);
     }
-    cmd = "client status";
+    cmd = "client status " + stringify(filesystem.fs_name) + "@" + stringify(filesystem.fscid);
     r = admin_socket->register_command(cmd, this,
                                        "provide the source client's status");
     if (r == 0) {
@@ -113,7 +113,6 @@ public:
            const bufferlist&,
            Formatter *f, std::ostream &errss, bufferlist &out) override {
     auto p = commands.at(std::string(command));
-    std::cout << "--->" << command << std::endl;
     return p->call(f);
   }
 

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -1,6 +1,6 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
-
+#include "common/ceph_json.h"
 #include "common/admin_socket.h"
 #include "common/ceph_argparse.h"
 #include "common/ceph_context.h"
@@ -65,6 +65,19 @@ private:
   FSMirror *fs_mirror;
 };
 
+class ClientStatusCommand : public MirrorAdminSocketCommand {
+public:
+  explicit ClientStatusCommand(FSMirror *fs_mirror) : fs_mirror(fs_mirror) {}
+
+  int call(Formatter *f) override {
+    fs_mirror->client_status(f);
+    return 0;
+  }
+
+private:
+  FSMirror *fs_mirror;
+};
+
 } // anonymous namespace
 
 class MirrorAdminSocketHook : public AdminSocketHook {
@@ -81,6 +94,12 @@ public:
     if (r == 0) {
       commands[cmd] = new StatusCommand(fs_mirror);
     }
+    cmd = "client status";
+    r = admin_socket->register_command(cmd, this,
+                                       "provide the source client's status");
+    if (r == 0) {
+      commands[cmd] = new ClientStatusCommand(fs_mirror);
+    }
   }
 
   ~MirrorAdminSocketHook() override {
@@ -94,6 +113,7 @@ public:
            const bufferlist&,
            Formatter *f, std::ostream &errss, bufferlist &out) override {
     auto p = commands.at(std::string(command));
+    std::cout << "--->" << command << std::endl;
     return p->call(f);
   }
 
@@ -453,6 +473,20 @@ void FSMirror::remove_peer(const Peer &peer) {
   }
   if (m_perf_counters) {
     m_perf_counters->dec(l_cephfs_mirror_fs_mirror_peers);
+  }
+}
+
+void FSMirror::client_status(Formatter *f) {
+  char* buf;
+  if (m_mount) {
+    int r = ceph_client_status(m_mount, &buf);
+    if (r == 0) {
+      JSONParser parser;
+      parser.parse(buf, std::strlen(buf));
+      JSONFormattable jf;
+      jf.decode_json(&parser);
+      jf.encode_json("", f);
+    }
   }
 }
 

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -93,6 +93,8 @@ public:
     return m_addrs;
   }
 
+  std::string get_daemon_id();
+
   // admin socket helpers
   void mirror_status(Formatter *f);
   void client_status(Formatter *f);

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -95,6 +95,7 @@ public:
 
   // admin socket helpers
   void mirror_status(Formatter *f);
+  void client_status(Formatter *f);
 
   void reopen_logs();
 

--- a/src/tools/cephfs_mirror/FileMirrorPool.cc
+++ b/src/tools/cephfs_mirror/FileMirrorPool.cc
@@ -140,7 +140,7 @@ void FileMirrorPool::sync_file_data(FileSyncMechanism *task, int sync_idx) {
     });
     if (!active) {
       task->complete(-1);
-      sq->give_cv.notify_one();
+      sq->give_cv.notify_all();
       return;
     }
     if (sq->sync_queue.empty()) {

--- a/src/tools/cephfs_mirror/FileMirrorPool.cc
+++ b/src/tools/cephfs_mirror/FileMirrorPool.cc
@@ -16,13 +16,14 @@ namespace cephfs {
 namespace mirror {
 
 std::string FileMirrorPool::FileWorker::state_name[] = {
-    "LOCKCONTEST",       "IDLE",
-    "CONSUME",           "EXECUTE",
-    "BACKOFF_CHECK1",    "BACKOFF_CHECK2",
-    "FILE_OPEN_LOCAL",   "FILE_OPEN_REMOTE",
-    "FILE_READ",         "FILE_WRITE",
-    "FILE_FSYNC",        "FREE_BUFFER",
-    "FILE_CLOSE_REMOTE", "FILE_CLOSE_LOCAL"};
+    "LOCKCONTEST",     "IDLE",
+    "CONSUME",         "EXECUTE",
+    "BACKOFF_CHECK1",  "BACKOFF_CHECK2",
+    "FILE_OPEN_LOCAL", "FILE_OPEN_REMOTE",
+    "FILE_READ",       "FILE_WRITE",
+    "FILE_FTRUNC",     "FILE_FSYNC",
+    "FREE_BUFFER",     "FILE_CLOSE_REMOTE",
+    "FILE_CLOSE_LOCAL"};
 
 FileMirrorPool::FileMirrorPool(int num_threads)
     : num_threads(num_threads), qlimit(std::max(10 * num_threads, 5000)),
@@ -116,7 +117,7 @@ void FileMirrorPool::run(FileWorker *file_worker) {
       task->set_worker_ref(file_worker);
     }
     sq->give_cv.notify_one();
-    task->complete(0);
+    task->complete(sq->get_low_level());
   }
 }
 
@@ -138,7 +139,7 @@ void FileMirrorPool::sync_file_data(FileSyncMechanism *task, int sync_idx) {
   pick_cv.notify_one();
 }
 
-int FileMirrorPool::sync_start(const std::string &dir_root) {
+int FileMirrorPool::sync_start(const std::string &dir_root, bool low_level) {
   std::scoped_lock lock(mtx);
   int sync_idx = 0;
   if (!unassigned_sync_ids.empty()) {
@@ -146,10 +147,12 @@ int FileMirrorPool::sync_start(const std::string &dir_root) {
     delete sync_queues[sync_idx];
     sync_queues[sync_idx] = nullptr;
     sync_queues[sync_idx] = new SyncQueue(dir_root);
+    sync_queues[sync_idx]->set_low_level(low_level);
     unassigned_sync_ids.pop_back();
   } else {
     sync_idx = sync_count++;
     sync_queues.emplace_back(new SyncQueue(dir_root));
+    sync_queues.back()->set_low_level(low_level);
   }
   return sync_idx;
 }

--- a/src/tools/cephfs_mirror/FileMirrorPool.cc
+++ b/src/tools/cephfs_mirror/FileMirrorPool.cc
@@ -106,8 +106,14 @@ void FileMirrorPool::run(FileWorker *file_worker) {
       task = sq->sync_queue.front();
       file_worker->current_syncing_file.file_name = std::move(task->get_file_name());
       file_worker->current_syncing_file.peer_uid = std::move(task->get_peer_uid());
-      file_worker->current_syncing_file.file_size = std::move(task->get_file_size());
+      file_worker->current_syncing_file.file_size = task->get_file_size();
       sq->sync_queue.pop();
+      if (sq->sync_stat) {
+        sq->sync_stat->current_stat.files_in_flight--;
+        sq->sync_stat->current_stat.files_data_synced++;
+        sq->sync_stat->current_stat.file_bytes_synced +=
+            file_worker->current_syncing_file.file_size;
+      }
       if (!sq->sync_queue.empty()) {
         sync_ring.emplace(sync_idx);
       }
@@ -117,6 +123,7 @@ void FileMirrorPool::run(FileWorker *file_worker) {
       task->set_worker_ref(file_worker);
     }
     sq->give_cv.notify_one();
+    task->local_stat = sq->local_stat;
     task->complete(sq->get_low_level());
   }
 }
@@ -125,10 +132,15 @@ void FileMirrorPool::sync_file_data(FileSyncMechanism *task, int sync_idx) {
   {
     std::unique_lock<std::mutex> lock(mtx);
     auto sq = sync_queues[sync_idx];
+    if (sq->sync_stat) {
+      sq->sync_stat->current_stat.files_in_flight++;
+    }
     sq->give_cv.wait(lock, [this, &sq] {
       return (!active || sq->sync_queue.size() < qlimit);
     });
     if (!active) {
+      task->complete(-1);
+      sq->give_cv.notify_one();
       return;
     }
     if (sq->sync_queue.empty()) {
@@ -139,19 +151,21 @@ void FileMirrorPool::sync_file_data(FileSyncMechanism *task, int sync_idx) {
   pick_cv.notify_one();
 }
 
-int FileMirrorPool::sync_start(const std::string &dir_root, bool low_level) {
+int FileMirrorPool::sync_start(const std::string &dir_root,
+                               const std::shared_ptr<SnapSyncStat> &sync_stat,
+                               bool low_level) {
   std::scoped_lock lock(mtx);
   int sync_idx = 0;
   if (!unassigned_sync_ids.empty()) {
     sync_idx = unassigned_sync_ids.back();
     delete sync_queues[sync_idx];
     sync_queues[sync_idx] = nullptr;
-    sync_queues[sync_idx] = new SyncQueue(dir_root);
+    sync_queues[sync_idx] = new SyncQueue(dir_root, sync_stat);
     sync_queues[sync_idx]->set_low_level(low_level);
     unassigned_sync_ids.pop_back();
   } else {
     sync_idx = sync_count++;
-    sync_queues.emplace_back(new SyncQueue(dir_root));
+    sync_queues.emplace_back(new SyncQueue(dir_root, sync_stat));
     sync_queues.back()->set_low_level(low_level);
   }
   return sync_idx;
@@ -163,6 +177,13 @@ void FileMirrorPool::sync_finish(int sync_idx, const std::string &dir_root) {
   ceph_assert(sync_queues[sync_idx]->dir_root == dir_root);
 
   sync_queues[sync_idx]->drain_queue();
+  if (sync_queues[sync_idx]->sync_stat) {
+    if (sync_queues[sync_idx]->local_stat) {
+      sync_queues[sync_idx]->local_stat->flush(
+          sync_queues[sync_idx]->sync_stat->current_stat);
+    }
+    sync_queues[sync_idx]->sync_stat = nullptr;
+  }
   unassigned_sync_ids.push_back(sync_idx);
 }
 
@@ -241,6 +262,12 @@ void FileMirrorPool::handle_conf_change(const ConfigProxy &conf,
 const char **FileMirrorPool::get_tracked_conf_keys() const {
   static const char *KEYS[] = {"cephfs_mirror_file_sync_thread", NULL};
   return KEYS;
+}
+
+FileMirrorPool::SyncQueue::SyncQueue(
+    const std::string &dir_root, const std::shared_ptr<SnapSyncStat> &sync_stat)
+    : dir_root(dir_root), sync_stat(sync_stat) {
+  local_stat = new LocalSyncStat();
 }
 
 void FileMirrorPool::SyncQueue::drain_queue() {

--- a/src/tools/cephfs_mirror/FileMirrorPool.cc
+++ b/src/tools/cephfs_mirror/FileMirrorPool.cc
@@ -26,9 +26,10 @@ std::string FileMirrorPool::FileWorker::state_name[] = {
     "FILE_CLOSE_LOCAL"};
 
 FileMirrorPool::FileMirrorPool(int num_threads)
-    : num_threads(num_threads), qlimit(std::max(10 * num_threads, 5000)),
-      sync_count(0), active(false) {
+    : num_threads(num_threads), sync_count(0), active(false) {
   g_conf().add_observer(this);
+  qlimit =
+      g_ceph_context->_conf.get_val<uint64_t>("cephfs_mirror_file_queue_size");
 }
 
 void FileMirrorPool::activate() {
@@ -63,6 +64,15 @@ void FileMirrorPool::deactivate() {
   }
 }
 
+void FileMirrorPool::deactivate_queue(int sync_idx) {
+  std::scoped_lock lock(mtx);
+  ceph_assert(sync_idx >= 0 && sync_idx < sync_queues.size());
+  auto sq = sync_queues[sync_idx];
+  sq->active = false;
+  sq->drain_queue();
+  pick_cv.notify_all();
+}
+
 void FileMirrorPool::drain_queue(int idx) {
   {
     std::scoped_lock lock(mtx);
@@ -78,13 +88,19 @@ void FileMirrorPool::drain_queue(int idx) {
 }
 
 void FileMirrorPool::run(FileWorker *file_worker) {
+  int sync_idx = -1;
+  FileSyncMechanism *task;
+  SyncQueue *sq = nullptr;
+  bool sq_active = true;
+  bool mirror_active = true;
+  bool found_task = false;
   while (true) {
     file_worker->state = FileWorker::ThreadState::LOCKCONTEST;
-    int sync_idx = -1;
-    FileSyncMechanism *task;
-    SyncQueue* sq = nullptr;
     {
       std::unique_lock<std::mutex> lock(mtx);
+      if (sq && found_task) {
+        sq->dec_in_flight();
+      }
       file_worker->state = FileWorker::ThreadState::IDLE;
       pick_cv.wait(lock, [this, file_worker] {
         return (file_worker->stop_called || !sync_ring.empty());
@@ -100,16 +116,16 @@ void FileMirrorPool::run(FileWorker *file_worker) {
       sq = sync_queues[sync_idx];
 
       if (sq->sync_queue.empty()) {
+        found_task = false;
         continue;
       }
 
       task = sq->sync_queue.front();
-      file_worker->current_syncing_file.file_name = std::move(task->get_file_name());
-      file_worker->current_syncing_file.peer_uid = std::move(task->get_peer_uid());
+      file_worker->current_syncing_file.file_name = task->get_file_name();
+      file_worker->current_syncing_file.peer_uid = task->get_peer_uid();
       file_worker->current_syncing_file.file_size = task->get_file_size();
       sq->sync_queue.pop();
       if (sq->sync_stat) {
-        sq->sync_stat->current_stat.files_in_flight--;
         sq->sync_stat->current_stat.files_data_synced++;
         sq->sync_stat->current_stat.file_bytes_synced +=
             file_worker->current_syncing_file.file_size;
@@ -121,10 +137,15 @@ void FileMirrorPool::run(FileWorker *file_worker) {
       file_worker->file_transferred++;
       file_worker->bytes_synced = 0;
       task->set_worker_ref(file_worker);
+      if (sq->sync_queue.size() < qlimit) {
+        sq->give_cv.notify_one();
+      }
+      sq_active = sq->active;
+      mirror_active = active;
+      found_task = true;
     }
-    sq->give_cv.notify_one();
     task->local_stat = sq->local_stat;
-    task->complete(sq->get_low_level());
+    task->complete((sq_active && mirror_active) ? sq->get_low_level() : -1);
   }
 }
 
@@ -136,10 +157,11 @@ void FileMirrorPool::sync_file_data(FileSyncMechanism *task, int sync_idx) {
       sq->sync_stat->current_stat.files_in_flight++;
     }
     sq->give_cv.wait(lock, [this, &sq] {
-      return (!active || sq->sync_queue.size() < qlimit);
+      return (!active || !sq->active || sq->sync_queue.size() < qlimit);
     });
-    if (!active) {
+    if (!active || !sq->active) {
       task->complete(-1);
+      sq->dec_in_flight();
       sq->give_cv.notify_all();
       return;
     }
@@ -149,6 +171,39 @@ void FileMirrorPool::sync_file_data(FileSyncMechanism *task, int sync_idx) {
     sq->sync_queue.emplace(task);
   }
   pick_cv.notify_one();
+}
+
+void FileMirrorPool::sync_file_data(std::queue<FileSyncMechanism *> *batch,
+                                    int sync_idx) {
+  {
+    std::unique_lock<std::mutex> lock(mtx);
+    auto sq = sync_queues[sync_idx];
+    if (sq->sync_stat) {
+      sq->sync_stat->current_stat.files_in_flight += batch->size();
+    }
+    sq->give_cv.wait(lock, [this, &sq] {
+      return (!active || !sq->active || sq->sync_queue.size() < qlimit);
+    });
+    if (!active || !sq->active) {
+      while (!batch->empty()) {
+        auto task = batch->front();
+        task->complete(-1);
+        sq->dec_in_flight();
+        batch->pop();
+      }
+      sq->give_cv.notify_all();
+      return;
+    }
+    if (sq->sync_queue.empty() && !batch->empty()) {
+      sync_ring.emplace(sync_idx);
+    }
+    while (!batch->empty()) {
+      auto task = batch->front();
+      sq->sync_queue.emplace(task);
+      batch->pop();
+    }
+  }
+  pick_cv.notify_all();
 }
 
 int FileMirrorPool::sync_start(const std::string &dir_root,
@@ -171,11 +226,8 @@ int FileMirrorPool::sync_start(const std::string &dir_root,
   return sync_idx;
 }
 
-void FileMirrorPool::sync_finish(int sync_idx, const std::string &dir_root) {
-  std::scoped_lock lock(mtx);
+void FileMirrorPool::sync_cleanup(int sync_idx) {
   ceph_assert(sync_idx >= 0 && sync_idx < sync_queues.size());
-  ceph_assert(sync_queues[sync_idx]->dir_root == dir_root);
-
   sync_queues[sync_idx]->drain_queue();
   if (sync_queues[sync_idx]->sync_stat) {
     if (sync_queues[sync_idx]->local_stat) {
@@ -185,6 +237,24 @@ void FileMirrorPool::sync_finish(int sync_idx, const std::string &dir_root) {
     sync_queues[sync_idx]->sync_stat = nullptr;
   }
   unassigned_sync_ids.push_back(sync_idx);
+}
+
+void FileMirrorPool::sync_finish(int sync_idx, const std::string &dir_root) {
+  std::unique_lock<std::mutex> lock(mtx);
+  ceph_assert(sync_idx >= 0 && sync_idx < sync_queues.size());
+  auto sq = sync_queues[sync_idx];
+  ceph_assert(sq->dir_root == dir_root);
+  sq->done = true;
+  pick_cv.notify_all();
+  if (sq->sync_stat && sq->sync_stat->current_stat.files_in_flight == 0) {
+    sq->sync_finish_cond->complete(0);
+  }
+  else {
+    lock.unlock();
+    sq->sync_finish_cond->wait();
+    lock.lock();
+  }
+  sync_cleanup(sync_idx);
 }
 
 void FileMirrorPool::update_state(int thread_count) {
@@ -256,11 +326,18 @@ void FileMirrorPool::handle_conf_change(const ConfigProxy &conf,
     update_state(g_ceph_context->_conf.get_val<uint64_t>(
         "cephfs_mirror_file_sync_thread"));
   }
-  dout(0) << ": cephfs_mirror_file_sync_thread=" << num_threads << dendl;
+  if (changed.count("cephfs_mirror_file_queue_size")) {
+    std::scoped_lock lock(mtx);
+    qlimit = g_ceph_context->_conf.get_val<uint64_t>(
+        "cephfs_mirror_file_queue_size");
+  }
+  dout(0) << ": cephfs_mirror_file_sync_thread=" << num_threads
+          << ", cephfs_mirror_file_queue_size=" << qlimit << dendl;
 }
 
 const char **FileMirrorPool::get_tracked_conf_keys() const {
-  static const char *KEYS[] = {"cephfs_mirror_file_sync_thread", NULL};
+  static const char *KEYS[] = {"cephfs_mirror_file_sync_thread",
+                               "cephfs_mirror_file_queue_size", NULL};
   return KEYS;
 }
 
@@ -268,6 +345,26 @@ FileMirrorPool::SyncQueue::SyncQueue(
     const std::string &dir_root, const std::shared_ptr<SnapSyncStat> &sync_stat)
     : dir_root(dir_root), sync_stat(sync_stat) {
   local_stat = new LocalSyncStat();
+  sync_finish_cond = std::make_unique<C_SaferCond>();
+  done = false;
+  active = true;
+}
+
+FileMirrorPool::SyncQueue::~SyncQueue() {
+  if (local_stat) {
+    delete local_stat;
+    local_stat = nullptr;
+  }
+}
+
+void FileMirrorPool::SyncQueue::dec_in_flight() {
+  if (sync_stat) {
+    sync_stat->current_stat.files_in_flight--;
+    if (done && sync_queue.empty() &&
+        sync_stat->current_stat.files_in_flight == 0) {
+      sync_finish_cond->complete(0);
+    }
+  }
 }
 
 void FileMirrorPool::SyncQueue::drain_queue() {
@@ -275,6 +372,7 @@ void FileMirrorPool::SyncQueue::drain_queue() {
     auto &task = sync_queue.front();
     task->complete(-1);
     sync_queue.pop();
+    dec_in_flight();
   }
   give_cv.notify_all();
 }

--- a/src/tools/cephfs_mirror/FileMirrorPool.h
+++ b/src/tools/cephfs_mirror/FileMirrorPool.h
@@ -25,7 +25,7 @@ class FileMirrorPool : public md_config_obs_t{
     void activate();
     void deactivate();
     void sync_file_data(FileSyncMechanism *task, int sync_idx);
-    int sync_start(const std::string &dir_root);
+    int sync_start(const std::string &dir_root, bool low_level = false);
     void sync_finish(int idx, const std::string &dir_root);
     void update_state(int thread_count);
     void drain_queue(int idx = -1);
@@ -48,6 +48,7 @@ class FileMirrorPool : public md_config_obs_t{
         FILE_OPEN_REMOTE,
         FILE_READ,
         FILE_WRITE,
+        FILE_FTRUNC,
         FILE_FSYNC,
         FREE_BUFFER,
         FILE_CLOSE_REMOTE,
@@ -83,6 +84,7 @@ class FileMirrorPool : public md_config_obs_t{
       std::string dir_root;
       std::queue<FileSyncMechanism *> sync_queue;
       std::condition_variable give_cv;
+      bool low_level = false;
       SyncQueue(const std::string &dir_root) : dir_root(dir_root) {}
       SyncQueue(const SyncQueue &other)
           : dir_root(other.dir_root), sync_queue(other.sync_queue) {}
@@ -95,6 +97,8 @@ class FileMirrorPool : public md_config_obs_t{
         return *this;
       }
       void drain_queue();
+      void set_low_level(bool _low_level) { low_level = _low_level; }
+      bool get_low_level() { return low_level; }
     };
 
     void run(FileWorker* file_worker);

--- a/src/tools/cephfs_mirror/FileMirrorPool.h
+++ b/src/tools/cephfs_mirror/FileMirrorPool.h
@@ -9,6 +9,7 @@
 #include "common/Formatter.h"
 #include "common/Thread.h"
 #include "common/config_obs.h"
+#include "common/Cond.h"
 
 
 namespace cephfs {
@@ -26,13 +27,16 @@ class FileMirrorPool : public md_config_obs_t{
                             const std::set<std::string> &changed) override;
     void activate();
     void deactivate();
+    void deactivate_queue(int sync_idx);
     void sync_file_data(FileSyncMechanism *task, int sync_idx);
+    void sync_file_data(std::queue<FileSyncMechanism *> *batch, int sync_idx);
     int sync_start(const std::string &dir_root,
                    const std::shared_ptr<SnapSyncStat> &sync_stat,
                    bool low_level = false);
     void sync_finish(int idx, const std::string &dir_root);
     void update_state(int thread_count);
     void drain_queue(int idx = -1);
+    void sync_cleanup(int sync_idx);
     void dump_stats(Formatter *f);
     struct FileWorker {
       struct FileInfo {
@@ -91,28 +95,36 @@ class FileMirrorPool : public md_config_obs_t{
       bool low_level = false;
       std::shared_ptr<SnapSyncStat> sync_stat = nullptr;
       LocalSyncStat* local_stat = nullptr;
+      bool done = false;
+      bool active = true;
+      std::unique_ptr<C_SaferCond> sync_finish_cond;
       SyncQueue(const std::string &dir_root,
                 const std::shared_ptr<SnapSyncStat> &sync_stat);
-      ~SyncQueue() {
-        if (local_stat) {
-          delete local_stat;
-          local_stat = nullptr;
-        }
-      }
+      ~SyncQueue();
       SyncQueue(const SyncQueue &other)
           : dir_root(other.dir_root), sync_queue(other.sync_queue),
-            sync_stat(other.sync_stat), local_stat(local_stat) {}
+            low_level(other.low_level), sync_stat(other.sync_stat),
+            local_stat(local_stat), done(other.done), active(other.active) {
+        sync_finish_cond = std::make_unique<C_SaferCond>();
+      }
 
       SyncQueue& operator=(const SyncQueue& other) {
         if (this != &other) {
           dir_root = other.dir_root;
           sync_queue = other.sync_queue;
+          low_level = other.low_level;
+          sync_stat = other.sync_stat;
+          local_stat = other.local_stat;
+          done = other.done;
+          active = other.active;
+          sync_finish_cond = std::make_unique<C_SaferCond>();
         }
         return *this;
       }
       void drain_queue();
       void set_low_level(bool _low_level) { low_level = _low_level; }
       bool get_low_level() { return low_level; }
+      void dec_in_flight();
     };
 
     void run(FileWorker* file_worker);

--- a/src/tools/cephfs_mirror/FileMirrorPool.h
+++ b/src/tools/cephfs_mirror/FileMirrorPool.h
@@ -15,6 +15,8 @@ namespace cephfs {
 namespace mirror {
 
 class FileSyncMechanism;
+class SnapSyncStat;
+class LocalSyncStat;
 
 class FileMirrorPool : public md_config_obs_t{
   public:
@@ -25,7 +27,9 @@ class FileMirrorPool : public md_config_obs_t{
     void activate();
     void deactivate();
     void sync_file_data(FileSyncMechanism *task, int sync_idx);
-    int sync_start(const std::string &dir_root, bool low_level = false);
+    int sync_start(const std::string &dir_root,
+                   const std::shared_ptr<SnapSyncStat> &sync_stat,
+                   bool low_level = false);
     void sync_finish(int idx, const std::string &dir_root);
     void update_state(int thread_count);
     void drain_queue(int idx = -1);
@@ -85,9 +89,19 @@ class FileMirrorPool : public md_config_obs_t{
       std::queue<FileSyncMechanism *> sync_queue;
       std::condition_variable give_cv;
       bool low_level = false;
-      SyncQueue(const std::string &dir_root) : dir_root(dir_root) {}
+      std::shared_ptr<SnapSyncStat> sync_stat = nullptr;
+      LocalSyncStat* local_stat = nullptr;
+      SyncQueue(const std::string &dir_root,
+                const std::shared_ptr<SnapSyncStat> &sync_stat);
+      ~SyncQueue() {
+        if (local_stat) {
+          delete local_stat;
+          local_stat = nullptr;
+        }
+      }
       SyncQueue(const SyncQueue &other)
-          : dir_root(other.dir_root), sync_queue(other.sync_queue) {}
+          : dir_root(other.dir_root), sync_queue(other.sync_queue),
+            sync_stat(other.sync_stat), local_stat(local_stat) {}
 
       SyncQueue& operator=(const SyncQueue& other) {
         if (this != &other) {

--- a/src/tools/cephfs_mirror/MirrorWatcher.cc
+++ b/src/tools/cephfs_mirror/MirrorWatcher.cc
@@ -79,6 +79,7 @@ void MirrorWatcher::handle_notify(uint64_t notify_id, uint64_t handle,
   JSONFormatter f;
   f.open_object_section("info");
   encode_json("addr", m_fs_mirror->get_instance_addr(), &f);
+  encode_json("daemon_id", m_fs_mirror->get_daemon_id(), &f);
   f.close_section();
 
   bufferlist outbl;

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1104,7 +1104,7 @@ int FileSyncMechanism::ll_copy_to_remote() {
     r = ceph_ll_create(replayer->m_remote_mount,
                        cur_entry->fh.ll_info.r_info.parent->inode.get(),
                        cur_entry->fh.ll_info.r_info.path.c_str(),
-                       cur_entry->stx.stx_mode, O_CREAT | O_WRONLY | O_NOFOLLOW,
+                       cur_entry->stx.stx_mode, O_CREAT | O_WRONLY | O_NOFOLLOW | O_TRUNC,
                        &inode_raw, &fh_raw, &rstx, 0, replayer->sync_flags,
                        replayer->m_remote_perms);
     if (r < 0) {
@@ -1121,7 +1121,8 @@ int FileSyncMechanism::ll_copy_to_remote() {
   } else {
     r = ceph_ll_open(replayer->m_remote_mount,
                      cur_entry->fh.ll_info.r_info.inode.get(),
-                     O_WRONLY | O_NOFOLLOW, &fh_raw, replayer->m_remote_perms);
+                     O_WRONLY | O_NOFOLLOW | O_TRUNC,
+                     &fh_raw, replayer->m_remote_perms);
     if (r < 0) {
       derr << ": failed to open remote file path="
            << abs_path(registry->dir_root, cur_entry->epath) << ": "
@@ -1183,15 +1184,6 @@ int FileSyncMechanism::ll_copy_to_remote() {
   if (r < 0) {
     goto free_ptr;
   }
-  file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_FTRUNC;
-  r = ll_update_remote_stat();
-  if (r < 0) {
-    derr << ": failed to populate low level stat of remote cur entry"
-            "entry= "
-         << abs_path(registry->dir_root, cur_entry->epath) << ": "
-         << cpp_strerror(r) << dendl;
-    goto free_ptr;
-  }
 
   file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_FSYNC;
   r = ceph_ll_fsync(replayer->m_remote_mount, r_fh.get(), 0);
@@ -1201,6 +1193,30 @@ int FileSyncMechanism::ll_copy_to_remote() {
          << cpp_strerror(r) << dendl;
     goto free_ptr;
   }
+  file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_FTRUNC;
+  r = ll_update_remote_stat();
+  if (r < 0) {
+    derr << ": failed to populate low level stat of remote cur entry"
+            "entry= "
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    goto free_ptr;
+  }
+  // if (fh.p_mnt == replayer->m_remote_mount) {
+  //   dout(0) << ": --->" << cur_entry->epath
+  //          << ", p_inode=" << cur_entry->fh.ll_info.p_info.inode
+  //          << ", c_inode=" << cur_entry->fh.ll_info.c_info.inode
+  //          << ", r_inode=" << cur_entry->fh.ll_info.r_info.inode
+  //          << ", S_ISDIR(cur_entry->stx.stx_mode)=" << S_ISDIR(cur_entry->stx.stx_mode)
+  //          << ", create_fresh=" << cur_entry->create_fresh()
+  //          << ", purge_remote=" << cur_entry->purge_remote()
+  //          << ", cur_entry->stx.stx_mtime=" << cur_entry->stx.stx_mtime
+  //          << ", cur_entry->pstx.stx_mtime=" << cur_entry->pstx.stx_mtime
+  //          << ", cur_entry->stx.stx_size=" << cur_entry->stx.stx_size
+  //          << ", cur_entry->pstx.stx_size=" << cur_entry->pstx.stx_size
+  //          << ", total_wrote=" << total_wrote
+  //          << dendl;
+  // }
 free_ptr:
   free(ptr);
   // dout(0) << ": 2--->" << cur_entry->epath << dendl;
@@ -2664,9 +2680,9 @@ int SyncMechanism::ll_update_remote_stat() {
     if ((cstx.stx_mode & ~S_IFMT) != (pstx.stx_mode & ~S_IFMT)) {
       mask = mask | CEPH_SETATTR_MODE;
     }
-    if (cstx.stx_size != pstx.stx_size && !S_ISDIR(cstx.stx_mode)) {
-      mask = mask | CEPH_SETATTR_SIZE;
-    }
+    // if (cstx.stx_size != pstx.stx_size && !S_ISDIR(cstx.stx_mode)) {
+    //   mask = mask | CEPH_SETATTR_SIZE;
+    // }
     if (cstx.stx_uid != pstx.stx_uid) {
       mask = mask | CEPH_SETATTR_UID;
     }
@@ -2679,7 +2695,8 @@ int SyncMechanism::ll_update_remote_stat() {
   } else {
     mask = CEPH_SETATTR_MODE | CEPH_SETATTR_UID | CEPH_SETATTR_GID;
     if (!S_ISDIR(cstx.stx_mode)) {
-      mask |= (CEPH_SETATTR_MTIME | CEPH_SETATTR_SIZE);
+      // mask |= (CEPH_SETATTR_MTIME | CEPH_SETATTR_SIZE);
+      mask |= (CEPH_SETATTR_MTIME);
     }
   }
   if (S_ISDIR(cstx.stx_mode)) {
@@ -3702,9 +3719,6 @@ int DirBruteDiffSync::go_next() {
 }
 
 int DirBruteDiffSync::ll_sync_current_entry() {
-  // dout(0) << ": --->" << cur_entry->epath << ", "
-  //         << ((fh.p_mnt == replayer->m_remote_mount) ? "remote" : "local")
-  //         << dendl;
   int r = 0;
   bool failed_prev =
       (sync_stat->synced_snap_count == 0 || sync_stat->nr_failures > 0);
@@ -3753,6 +3767,21 @@ int DirBruteDiffSync::ll_sync_current_entry() {
   }
 
   ll_populate_remote_inode_with_diff_base();
+  // if (fh.p_mnt == replayer->m_remote_mount) {
+  //   dout(0) << ": --->" << cur_entry->epath
+  //          << ", p_inode=" << cur_entry->fh.ll_info.p_info.inode
+  //          << ", c_inode=" << cur_entry->fh.ll_info.c_info.inode
+  //          << ", r_inode=" << cur_entry->fh.ll_info.r_info.inode
+  //          << ", S_ISDIR(cur_entry->stx.stx_mode)=" << S_ISDIR(cur_entry->stx.stx_mode)
+  //          << ", create_fresh=" << cur_entry->create_fresh()
+  //          << ", purge_remote=" << cur_entry->purge_remote()
+  //          << ", cur_entry->stx.stx_mtime=" << cur_entry->stx.stx_mtime
+  //          << ", cur_entry->pstx.stx_mtime=" << cur_entry->pstx.stx_mtime
+  //          << ", cur_entry->stx.stx_size=" << cur_entry->stx.stx_size
+  //          << ", cur_entry->pstx.stx_size=" << cur_entry->pstx.stx_size
+  //          << ", need_data_sync=" << need_data_sync
+  //          << dendl;
+  // }
 
   if (cur_entry->purge_remote()) {
     SyncMechanism *syncm = new LL_DeleteMechanism(

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -965,21 +965,32 @@ int PeerReplayer::_remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
 }
 
 int SyncMechanism::ll_remote_mkdir() {
-  ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.r_inode == nullptr);
-  int r = 0;
+  int r = replayer->ll_reduce_gap(replayer->m_remote_mount,
+                                  cur_entry->fh.ll_info.r_info,
+                                  replayer->m_remote_perms);
+  if (r < 0) {
+    derr << ": failed to reduce gap for remote cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+  ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  ceph_assert(cur_entry->fh.ll_info.r_info.inode == nullptr);
+  r = 0;
   InodeRawPtr raw_inode = nullptr;
   struct ceph_statx rstx;
   r = ceph_ll_mkdir(replayer->m_remote_mount,
-                    cur_entry->fh.ll_info.r_parent_inode.back().get(),
-                    cur_entry->fh.ll_info.r_path.c_str(),
+                    cur_entry->fh.ll_info.r_info.parent->inode.get(),
+                    cur_entry->fh.ll_info.r_info.path.c_str(),
                     cur_entry->stx.stx_mode & ~S_IFDIR, &raw_inode, &rstx, 0,
                     replayer->sync_flags, replayer->m_remote_perms);
   if (r < 0) {
     return r;
   }
   ceph_assert(raw_inode != nullptr);
-  cur_entry->fh.ll_info.r_inode =
+  cur_entry->fh.ll_info.r_info.inode =
       create_inode_shared_ptr(replayer->m_remote_mount, raw_inode);
   local_stat->inc_dir_created_count(sync_stat->current_stat,
                                     replayer->stat_flush_counter_gap);
@@ -1021,10 +1032,12 @@ int FileSyncMechanism::ll_copy_to_remote() {
   }
   file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_OPEN_LOCAL;
   FhRawPtr fh_raw = nullptr;
-  ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+  ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
   // dout(0) << ": --->" << cur_entry->epath
   //         << ", in=" << cur_entry->fh.ll_info.c_inode.get() << dendl;
-  r = ceph_ll_open(replayer->m_local_mount, cur_entry->fh.ll_info.c_inode.get(),
+  r = ceph_ll_open(replayer->m_local_mount,
+                   cur_entry->fh.ll_info.c_info.inode.get(),
                    O_RDONLY | O_NOFOLLOW, &fh_raw, replayer->m_local_perms);
   if (r < 0) {
     derr << ": failed to open cur snapshot's file path="
@@ -1039,15 +1052,26 @@ int FileSyncMechanism::ll_copy_to_remote() {
 
   struct ceph_statx rstx;
   fh_raw = nullptr;
-  if (cur_entry->fh.ll_info.r_inode == nullptr) {
+  if (cur_entry->fh.ll_info.r_info.inode == nullptr) {
     ll_populate_remote_inode_with_diff_base();
   }
-  if (cur_entry->fh.ll_info.r_inode == nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
+  if (cur_entry->fh.ll_info.r_info.inode == nullptr) {
+    r = replayer->ll_reduce_gap(replayer->m_remote_mount,
+                                cur_entry->fh.ll_info.r_info,
+                                replayer->m_remote_perms);
+    if (r < 0) {
+      derr << ": failed to reduce gap for remote cur entry="
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
     InodeRawPtr inode_raw = nullptr;
     r = ceph_ll_create(replayer->m_remote_mount,
-                       cur_entry->fh.ll_info.r_parent_inode.back().get(),
-                       cur_entry->fh.ll_info.r_path.c_str(),
+                       cur_entry->fh.ll_info.r_info.parent->inode.get(),
+                       cur_entry->fh.ll_info.r_info.path.c_str(),
                        cur_entry->stx.stx_mode, O_CREAT | O_WRONLY | O_NOFOLLOW,
                        &inode_raw, &fh_raw, &rstx, 0, replayer->sync_flags,
                        replayer->m_remote_perms);
@@ -1058,12 +1082,12 @@ int FileSyncMechanism::ll_copy_to_remote() {
       return r;
     }
     ceph_assert(inode_raw != nullptr);
-    cur_entry->fh.ll_info.r_inode =
+    cur_entry->fh.ll_info.r_info.inode =
         create_inode_shared_ptr(replayer->m_remote_mount, inode_raw);
   } else {
     r = ceph_ll_open(replayer->m_remote_mount,
-                     cur_entry->fh.ll_info.r_inode.get(), O_WRONLY | O_NOFOLLOW,
-                     &fh_raw, replayer->m_remote_perms);
+                     cur_entry->fh.ll_info.r_info.inode.get(),
+                     O_WRONLY | O_NOFOLLOW, &fh_raw, replayer->m_remote_perms);
     if (r < 0) {
       derr << ": failed to open remote file path="
            << abs_path(registry->dir_root, cur_entry->epath) << ": "
@@ -1280,17 +1304,28 @@ void PeerReplayer::enqueue_file_transfer(
 }
 
 int SyncMechanism::ll_unlink_cur_file_entry() {
-  ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
-  int r = ceph_ll_unlink(replayer->m_remote_mount,
-                         cur_entry->fh.ll_info.r_parent_inode.back().get(),
-                         cur_entry->fh.ll_info.r_path.c_str(),
-                         replayer->m_remote_perms);
+  int r = replayer->ll_reduce_gap(replayer->m_remote_mount,
+                                  cur_entry->fh.ll_info.r_info,
+                                  replayer->m_remote_perms);
+  if (r < 0) {
+    derr << ": failed to reduce gap for remote cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+  ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  r = ceph_ll_unlink(replayer->m_remote_mount,
+                     cur_entry->fh.ll_info.r_info.parent->inode.get(),
+                     cur_entry->fh.ll_info.r_info.path.c_str(),
+                     replayer->m_remote_perms);
   if (r < 0 && r != -ENOENT) {
     return r;
   }
-  cur_entry->fh.ll_info.r_inode = nullptr;
+  cur_entry->fh.ll_info.r_info.inode = nullptr;
   if (fh.p_mnt == replayer->m_remote_mount) {
-    cur_entry->fh.ll_info.p_inode = nullptr;
+    cur_entry->fh.ll_info.p_info.inode = nullptr;
   }
   local_stat->inc_files_deleted_count(sync_stat->current_stat,
                                       replayer->stat_flush_counter_gap);
@@ -1299,17 +1334,28 @@ int SyncMechanism::ll_unlink_cur_file_entry() {
 }
 
 int SyncMechanism::ll_unlink_cur_dir_entry() {
-  ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
-  int r = ceph_ll_rmdir(replayer->m_remote_mount,
-                        cur_entry->fh.ll_info.r_parent_inode.back().get(),
-                        cur_entry->fh.ll_info.r_path.c_str(),
+  int r = replayer->ll_reduce_gap(replayer->m_remote_mount,
+                                  cur_entry->fh.ll_info.r_info,
+                                  replayer->m_remote_perms);
+  if (r < 0) {
+    derr << ": failed to reduce gap for remote cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+  ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  r = ceph_ll_rmdir(replayer->m_remote_mount,
+                        cur_entry->fh.ll_info.r_info.parent->inode.get(),
+                        cur_entry->fh.ll_info.r_info.path.c_str(),
                         replayer->m_remote_perms);
   if (r < 0 && r != -ENOENT) {
     return r;
   }
-  cur_entry->fh.ll_info.r_inode = nullptr;
+  cur_entry->fh.ll_info.r_info.inode = nullptr;
   if (fh.p_mnt == replayer->m_remote_mount) {
-    cur_entry->fh.ll_info.p_inode = nullptr;
+    cur_entry->fh.ll_info.p_info.inode = nullptr;
   }
   // dout(0) << ": --->" << cur_entry->epath << dendl;
   local_stat->inc_dir_deleted_count(sync_stat->current_stat,
@@ -1349,9 +1395,9 @@ int SyncMechanism::ll_remote_file_op() {
         return r;
       }
       char *target = (char *)alloca(cstx.stx_size + 1);
-      ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+      ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
       r = ceph_ll_readlink(replayer->m_local_mount,
-                           cur_entry->fh.ll_info.c_inode.get(), target,
+                           cur_entry->fh.ll_info.c_info.inode.get(), target,
                            cstx.stx_size, replayer->m_local_perms);
       if (r < 0) {
         derr << "failed to do low level readlink of local current snapshot's "
@@ -1361,12 +1407,15 @@ int SyncMechanism::ll_remote_file_op() {
              << ": " << cpp_strerror(r) << dendl;
         return r;
       }
+      ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+      ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+      ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
       struct ceph_statx rstx;
       InodeRawPtr link_raw = nullptr;
       target[cstx.stx_size] = '\0';
       r = ceph_ll_symlink(replayer->m_remote_mount,
-                          cur_entry->fh.ll_info.r_parent_inode.back().get(),
-                          cur_entry->fh.ll_info.r_path.c_str(), target,
+                          cur_entry->fh.ll_info.r_info.parent->inode.get(),
+                          cur_entry->fh.ll_info.r_info.path.c_str(), target,
                           &link_raw, &rstx, 0, replayer->sync_flags,
                           replayer->m_remote_perms);
 
@@ -1376,10 +1425,10 @@ int SyncMechanism::ll_remote_file_op() {
              << cpp_strerror(r) << dendl;
         return r;
       } else if (r == -EEXIST) {
-        cur_entry->fh.ll_info.r_inode = nullptr;
+        cur_entry->fh.ll_info.r_info.inode = nullptr; // need to check
       } else {
         ceph_assert(link_raw != nullptr);
-        cur_entry->fh.ll_info.r_inode =
+        cur_entry->fh.ll_info.r_info.inode =
             create_inode_shared_ptr(replayer->m_remote_mount, link_raw);
       }
       cur_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
@@ -1479,8 +1528,9 @@ int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
 
 int SyncMechanism::ll_cleanup_remote_entry() {
   // dout(0) << ": --->" << cur_entry->epath << dendl;
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
   int r = 0;
-  ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
   if (cur_entry->prev_d_type != DT_DIR) {
     r = ll_unlink_cur_file_entry();
     if (r == 0) {
@@ -1495,10 +1545,11 @@ int SyncMechanism::ll_cleanup_remote_entry() {
     } else if (r == -ENOENT) {
       return 0;
     }
-    ceph_assert(cur_entry->fh.ll_info.r_inode != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_info.inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
     r = replayer->ll_open_dirp(replayer->m_remote_mount,
-                               cur_entry->fh.ll_info.r_inode, cur_entry->udirp,
-                               replayer->m_remote_perms);
+                               cur_entry->fh.ll_info.r_info.inode,
+                               cur_entry->udirp, replayer->m_remote_perms);
     if (r < 0 && r != -ENOENT) {
       derr << ": failed to open low level inode of remote cur entry="
            << abs_path(registry->dir_root, cur_entry->epath) << ": "
@@ -1521,10 +1572,11 @@ int SyncMechanism::ll_cleanup_remote_entry() {
       }
       return 0;
     }
-    ceph_assert(cur_entry->fh.ll_info.r_inode != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_info.inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
     r = replayer->ll_open_dirp(replayer->m_remote_mount,
-                               cur_entry->fh.ll_info.r_inode, cur_entry->udirp,
-                               replayer->m_remote_perms);
+                               cur_entry->fh.ll_info.r_info.inode,
+                               cur_entry->udirp, replayer->m_remote_perms);
     if (r == -ENOENT) {
       return 0;
     } else if (r < 0) {
@@ -1565,7 +1617,7 @@ int SyncMechanism::ll_cleanup_remote_entry() {
     d_entry->rollout(cur_entry->fh, d_name);
     d_entry->prev_d_type = (int)de.d_type;
     ceph_assert(r_inode_raw != nullptr);
-    d_entry->fh.ll_info.r_inode =
+    d_entry->fh.ll_info.r_info.inode =
         create_inode_shared_ptr(replayer->m_remote_mount, r_inode_raw);
     SyncMechanism *syncm =
         new LL_DeleteMechanism(replayer->m_local_mount, std::move(d_entry),
@@ -1801,12 +1853,14 @@ int PeerReplayer::should_sync_entry(const std::string &epath, const struct ceph_
 
 int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
   // dout(0) << ": --->" << cur_entry->epath << dendl;
-  ceph_assert(cur_entry->fh.ll_info.p_inode != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.p_info.inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+  ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
+  ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
   int r = 0;
   DirUniquePtr udirp;
-  r = replayer->ll_open_dirp(fh.p_mnt, cur_entry->fh.ll_info.p_inode, udirp,
-                             fh.ll_info.p_perms);
+  r = replayer->ll_open_dirp(fh.p_mnt, cur_entry->fh.ll_info.p_info.inode,
+                             udirp, fh.ll_info.p_perms);
   if (r < 0) {
     if (r == -ELOOP || r == -ENOTDIR || r == -ENOENT) {
       return 0;
@@ -1817,6 +1871,9 @@ int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
   struct dirent de;
   struct ceph_statx pstx, cstx;
   while (true) {
+    if (replayer->should_backoff(registry, &r)) {
+      return r;
+    }
     unsigned int extra_flags =
         (cache_size < replayer->max_element_in_cache_per_thread)
             ? (CEPH_STATX_UID | CEPH_STATX_GID | CEPH_STATX_SIZE |
@@ -1847,8 +1904,8 @@ int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
     std::string epath = std::move(entry_path(cur_entry->epath, d_name));
     InodeSharedPtr c_inode = nullptr;
     r = replayer->ll_open_inode(
-        replayer->m_local_mount, cur_entry->fh.ll_info.c_inode, d_name, c_inode,
-        cstx, extra_flags | CEPH_STATX_MODE, replayer->m_local_perms);
+        replayer->m_local_mount, cur_entry->fh.ll_info.c_info.inode, d_name,
+        c_inode, cstx, extra_flags | CEPH_STATX_MODE, replayer->m_local_perms);
     if (r < 0 && r != -ENOENT) {
       derr << ": failed to do low level openning of cur snapshot's cur entry="
            << abs_path(registry->dir_root, epath, fh.m_current.first,
@@ -1875,7 +1932,7 @@ int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
           std::make_shared<PeerReplayer::SyncEntry>(std::move(epath));
       d_entry->rollout(cur_entry->fh, d_name);
       d_entry->prev_d_type = (int)de.d_type;
-      d_entry->fh.ll_info.p_inode = std::move(p_inode);
+      d_entry->fh.ll_info.p_info.inode = std::move(p_inode);
       SyncMechanism *syncm =
           new LL_DeleteMechanism(replayer->m_local_mount, std::move(d_entry),
                                  registry, sync_stat, fh, replayer);
@@ -2003,7 +2060,7 @@ int PeerReplayer::propagate_deleted_entries(
   return r;
 }
 
-int PeerReplayer::ll_open_inode(MountRef mnt, InodeSharedPtr &parent_inode,
+int PeerReplayer::ll_open_inode(MountRef mnt, InodeSharedPtr &parent,
                                 const std::string &dir_path,
                                 InodeSharedPtr &inode_shared,
                                 struct ceph_statx &stx, unsigned int want,
@@ -2011,16 +2068,71 @@ int PeerReplayer::ll_open_inode(MountRef mnt, InodeSharedPtr &parent_inode,
   dout(20) << ": dir_path=" << dir_path << dendl;
 
   InodeRawPtr inode = nullptr;
-  int r =
-      ceph_ll_lookup(mnt, parent_inode.get(), dir_path.c_str(), &inode, &stx,
-                     want, sync_flags, perms);
+  int r = ceph_ll_lookup(mnt, parent.get(), dir_path.c_str(), &inode, &stx,
+                         want, sync_flags, perms);
   if (r < 0) {
     inode = nullptr;
-  } else {
-    ceph_assert(inode != nullptr);
+    inode_shared = nullptr;
+    return r;
   }
+  ceph_assert(inode != nullptr);
   inode_shared = create_inode_shared_ptr(mnt, inode);
-  return (r < 0 ? r : 0);
+  return 0;
+}
+
+int PeerReplayer::ll_reduce_gap(MountRef mnt,
+                                FHandles::LL_Fhandle_Info::InodeInfo &info,
+                                UserPermRef perms) {
+  ceph_assert(info.parent != nullptr);
+  ceph_assert(info.parent->inode != nullptr);
+  if (!info.gap) {
+    return 0;
+  }
+  std::string& dir_path = info.path;
+  struct ceph_statx stx;
+  int i, j;
+  for(j = 0; j < dir_path.size() && dir_path[j] == '/'; ++j);
+  for (i = j; i < dir_path.size(); i = j) {
+    std::string dir_name = "";
+    for (; j < dir_path.size() && dir_path[j] != '/'; ++j) {
+      dir_name += dir_path[j];
+    }
+    for(; j < dir_path.size() && dir_path[j] == '/'; ++j);
+    if (j == dir_path.size()) {
+      info.path = std::move(dir_name);
+      break;
+    }
+    InodeRawPtr inode = nullptr;
+    int r = ceph_ll_lookup(mnt, info.parent->inode.get(), dir_name.c_str(),
+                           &inode, &stx, 0, sync_flags, perms);
+    if (r < 0) {
+      inode = nullptr;
+      return r;
+    }
+    ceph_assert(inode != nullptr);
+    info.parent = std::make_shared<AncestorsLink>(
+        std::move(info.parent), std::move(create_inode_shared_ptr(mnt, inode)));
+  }
+  info.gap = false;
+  return 0;
+}
+
+int PeerReplayer::ll_open_inode(MountRef mnt,
+                                FHandles::LL_Fhandle_Info::InodeInfo &info,
+                                struct ceph_statx &stx, unsigned int want,
+                                UserPermRef perms) {
+  int r = ll_reduce_gap(mnt, info, perms);
+  if (r < 0) {
+    info.inode = nullptr;
+    derr << ": failed to reduce gap for " << info.path << dendl;
+    return r;
+  }
+  r = ll_open_inode(mnt, info.parent->inode, info.path, info.inode, stx, want,
+                    perms);
+  if (r < 0) {
+    return r;
+  }
+  return 0;
 }
 
 int PeerReplayer::ll_open_dirp(MountRef mnt, InodeSharedPtr &inode,
@@ -2029,11 +2141,12 @@ int PeerReplayer::ll_open_dirp(MountRef mnt, InodeSharedPtr &inode,
   int r = ceph_ll_opendir(mnt, inode.get(), &rdirp, perms);
   if (r < 0) {
     rdirp = nullptr;
-  } else {
-    ceph_assert(rdirp != nullptr);
+    udirp = nullptr;
+    return r;
   }
+  ceph_assert(rdirp != nullptr);
   udirp = create_dirp_unique_ptr(mnt, rdirp);
-  return (r < 0 ? r : 0);
+  return 0;
 }
 
 int PeerReplayer::open_dir(MountRef mnt, const std::string &dir_path,
@@ -2085,9 +2198,12 @@ int PeerReplayer::ll_pre_sync_check_and_open_registry_inodes(
   auto cur_snap_path = snapshot_path(m_cct, cur_path, current.first);
 
   struct ceph_statx stx;
-
-  int r = ll_open_inode(m_local_mount, m_local_root_inode, cur_snap_path,
-                        registry->remotediff_fh.ll_info.c_parent_inode.back(),
+  registry->remotediff_fh.ll_info.c_info.parent =
+      std::make_shared<AncestorsLink>(nullptr, m_local_root_inode);
+  registry->remotediff_fh.ll_info.c_info.path = cur_snap_path;
+  registry->remotediff_fh.ll_info.c_info.inode = nullptr;
+  registry->remotediff_fh.ll_info.c_info.gap = true;
+  int r = ll_open_inode(m_local_mount, registry->remotediff_fh.ll_info.c_info,
                         stx, 0, m_local_perms);
 
   if (r < 0) {
@@ -2096,16 +2212,19 @@ int PeerReplayer::ll_pre_sync_check_and_open_registry_inodes(
          << cur_snap_path << ": " << cpp_strerror(r) << dendl;
     return r;
   }
-  registry->snapdiff_fh.ll_info.c_parent_inode =
-      registry->remotediff_fh.ll_info.c_parent_inode;
+  registry->snapdiff_fh.ll_info.c_info = registry->remotediff_fh.ll_info.c_info;
   registry->snapdiff_fh.m_current = current;
   registry->remotediff_fh.m_current = current;
   registry->snapdiff_fh.m_prev = prev;
 
   if (prev) {
     auto prev_snap_path = snapshot_path(m_cct, cur_path, (*prev).first);
-    r = ll_open_inode(m_local_mount, m_local_root_inode, prev_snap_path,
-                      registry->snapdiff_fh.ll_info.p_parent_inode.back(), stx,
+    registry->snapdiff_fh.ll_info.p_info.parent =
+        std::make_shared<AncestorsLink>(nullptr, m_local_root_inode);
+    registry->snapdiff_fh.ll_info.p_info.path = prev_snap_path;
+    registry->snapdiff_fh.ll_info.p_info.inode = nullptr;
+    registry->snapdiff_fh.ll_info.p_info.gap = true;
+    r = ll_open_inode(m_local_mount, registry->snapdiff_fh.ll_info.p_info, stx,
                       0, m_local_perms);
     if (r < 0) {
       derr << ": error occurred while doing low level opening of local inode "
@@ -2115,8 +2234,12 @@ int PeerReplayer::ll_pre_sync_check_and_open_registry_inodes(
     registry->snapdiff_fh.p_mnt = m_local_mount;
     registry->snapdiff_fh.ll_info.p_perms = m_local_perms;
   }
-  r = ll_open_inode(m_remote_mount, m_remote_root_inode, cur_path,
-                    registry->remotediff_fh.ll_info.r_parent_inode.back(), stx,
+  registry->remotediff_fh.ll_info.r_info.parent =
+      std::make_shared<AncestorsLink>(nullptr, m_remote_root_inode);
+  registry->remotediff_fh.ll_info.r_info.path = cur_path;
+  registry->remotediff_fh.ll_info.r_info.inode = nullptr;
+  registry->remotediff_fh.ll_info.r_info.gap = true;
+  r = ll_open_inode(m_remote_mount, registry->remotediff_fh.ll_info.r_info, stx,
                     0, m_remote_perms);
   if (r < 0) {
     derr << ": error occurred while opening remote low level inode of dir="
@@ -2124,24 +2247,50 @@ int PeerReplayer::ll_pre_sync_check_and_open_registry_inodes(
     return r;
   }
   registry->remotediff_fh.p_mnt = m_remote_mount;
-  registry->snapdiff_fh.ll_info.r_parent_inode =
-      registry->remotediff_fh.ll_info.p_parent_inode =
-          registry->remotediff_fh.ll_info.r_parent_inode;
+  registry->snapdiff_fh.ll_info.r_info =
+      registry->remotediff_fh.ll_info.p_info =
+          registry->remotediff_fh.ll_info.r_info;
 
   registry->remotediff_fh.ll_info.p_perms = m_remote_perms;
 
-  registry->snapdiff_fh.ll_info.c_inode =
-      registry->snapdiff_fh.ll_info.c_parent_inode.back();
-  registry->snapdiff_fh.ll_info.p_inode =
-      registry->snapdiff_fh.ll_info.p_parent_inode.back();
-  registry->snapdiff_fh.ll_info.r_inode =
-      registry->snapdiff_fh.ll_info.r_parent_inode.back();
-  registry->remotediff_fh.ll_info.c_inode =
-      registry->remotediff_fh.ll_info.c_parent_inode.back();
-  registry->remotediff_fh.ll_info.p_inode =
-      registry->remotediff_fh.ll_info.p_parent_inode.back();
-  registry->remotediff_fh.ll_info.r_inode =
-      registry->remotediff_fh.ll_info.r_parent_inode.back();
+  registry->snapdiff_fh.ll_info.c_info.parent = std::make_shared<AncestorsLink>(
+      registry->snapdiff_fh.ll_info.c_info.parent,
+      registry->snapdiff_fh.ll_info.c_info.inode);
+  registry->snapdiff_fh.ll_info.c_info.path = "";
+  registry->snapdiff_fh.ll_info.c_info.gap = false;
+
+  registry->snapdiff_fh.ll_info.p_info.parent = std::make_shared<AncestorsLink>(
+      registry->snapdiff_fh.ll_info.p_info.parent,
+      registry->snapdiff_fh.ll_info.p_info.inode);
+  registry->snapdiff_fh.ll_info.p_info.path = "";
+  registry->snapdiff_fh.ll_info.p_info.gap = false;
+
+  registry->snapdiff_fh.ll_info.r_info.parent = std::make_shared<AncestorsLink>(
+      registry->snapdiff_fh.ll_info.r_info.parent,
+      registry->snapdiff_fh.ll_info.r_info.inode);
+  registry->snapdiff_fh.ll_info.r_info.path = "";
+  registry->snapdiff_fh.ll_info.r_info.gap = false;
+
+  registry->remotediff_fh.ll_info.c_info.parent =
+      std::make_shared<AncestorsLink>(
+          registry->remotediff_fh.ll_info.c_info.parent,
+          registry->remotediff_fh.ll_info.c_info.inode);
+  registry->remotediff_fh.ll_info.c_info.path = "";
+  registry->remotediff_fh.ll_info.c_info.gap = false;
+
+  registry->remotediff_fh.ll_info.p_info.parent =
+      std::make_shared<AncestorsLink>(
+          registry->remotediff_fh.ll_info.p_info.parent,
+          registry->remotediff_fh.ll_info.p_info.inode);
+  registry->remotediff_fh.ll_info.p_info.path = "";
+  registry->remotediff_fh.ll_info.p_info.gap = false;
+
+  registry->remotediff_fh.ll_info.r_info.parent =
+      std::make_shared<AncestorsLink>(
+          registry->remotediff_fh.ll_info.r_info.parent,
+          registry->remotediff_fh.ll_info.r_info.inode);
+  registry->remotediff_fh.ll_info.r_info.path = "";
+  registry->remotediff_fh.ll_info.r_info.gap = false;
   return 0;
 }
 
@@ -2403,11 +2552,12 @@ void PeerReplayer::DirSyncPool::update_qlimit(int _qlimit) {
 
 bool SyncMechanism::ll_populate_remote_inode_with_diff_base() {
   if (fh.p_mnt == replayer->m_remote_mount &&
-      cur_entry->fh.ll_info.p_inode != nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.p_parent_inode.back() != nullptr);
-    cur_entry->fh.ll_info.r_parent_inode = cur_entry->fh.ll_info.p_parent_inode;
-    cur_entry->fh.ll_info.r_inode = cur_entry->fh.ll_info.p_inode;
-    cur_entry->fh.ll_info.r_path = cur_entry->fh.ll_info.p_path;
+      cur_entry->fh.ll_info.r_info.inode == nullptr &&
+      cur_entry->fh.ll_info.p_info.inode != nullptr &&
+      !cur_entry->fh.ll_info.p_info.gap && cur_entry->fh.ll_info.r_info.gap) {
+    ceph_assert(cur_entry->fh.ll_info.p_info.parent != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.p_info.parent->inode != nullptr);
+    cur_entry->fh.ll_info.r_info = cur_entry->fh.ll_info.p_info;
     return true;
   }
   return false;
@@ -2415,17 +2565,17 @@ bool SyncMechanism::ll_populate_remote_inode_with_diff_base() {
 
 int SyncMechanism::ll_populate_remote_inode() {
   int r = 0;
-  if (cur_entry->fh.ll_info.r_inode != nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+  if (cur_entry->fh.ll_info.r_info.inode != nullptr) {
+    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
     return 0;
   }
   if (!ll_populate_remote_inode_with_diff_base()) {
-    ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
     struct ceph_statx rstx;
-    r = replayer->ll_open_inode(
-        replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.back(),
-        cur_entry->fh.ll_info.r_path, cur_entry->fh.ll_info.r_inode, rstx, 0,
-        replayer->m_remote_perms);
+    r = replayer->ll_open_inode(replayer->m_remote_mount,
+                                cur_entry->fh.ll_info.r_info, rstx, 0,
+                                replayer->m_remote_perms);
     if (r < 0) {
       return r;
     }
@@ -2480,9 +2630,10 @@ int SyncMechanism::ll_update_remote_stat() {
     return r;
   }
 
-  ceph_assert(cur_entry->fh.ll_info.r_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_info.inode != nullptr);
+  ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
   r = ceph_ll_setattr(replayer->m_remote_mount,
-                      cur_entry->fh.ll_info.r_inode.get(), &cstx, mask,
+                      cur_entry->fh.ll_info.r_info.inode.get(), &cstx, mask,
                       replayer->m_remote_perms);
 
   if (r < 0) {
@@ -2507,13 +2658,13 @@ int SyncMechanism::ll_populate_cur_stat_and_cur_inode() {
   int r = 0;
   int mask = CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
              CEPH_STATX_SIZE | CEPH_STATX_MTIME;
-  if (cur_entry->fh.ll_info.c_inode == nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.c_parent_inode.back() != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.c_info.parent != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.c_info.parent->inode != nullptr);
+  ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
+  if (cur_entry->fh.ll_info.c_info.inode == nullptr) {
     r = replayer->ll_open_inode(
-        replayer->m_local_mount, cur_entry->fh.ll_info.c_parent_inode.back(),
-        cur_entry->fh.ll_info.c_path, cur_entry->fh.ll_info.c_inode,
-        cur_entry->stx, (cur_entry->stat_known ? 0 : mask),
-        replayer->m_local_perms);
+        replayer->m_local_mount, cur_entry->fh.ll_info.c_info, cur_entry->stx,
+        (cur_entry->stat_known ? 0 : mask), replayer->m_local_perms);
     if (r < 0) {
       derr << ": failed to do low level opening of cur snapshot's cur entry= "
            << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
@@ -2522,10 +2673,9 @@ int SyncMechanism::ll_populate_cur_stat_and_cur_inode() {
       return r;
     }
   } else if (!cur_entry->stat_known) {
-    r = ceph_ll_getattr(replayer->m_local_mount,
-                        cur_entry->fh.ll_info.c_inode.get(), &cur_entry->stx,
-                        mask, replayer->sync_flags,
-                        replayer->m_local_perms);
+    r = ceph_ll_getattr(
+        replayer->m_local_mount, cur_entry->fh.ll_info.c_info.inode.get(),
+        &cur_entry->stx, mask, replayer->sync_flags, replayer->m_local_perms);
     if (r < 0) {
       derr << ": failed to gather low level stat of cur snapshot's cur entry= "
            << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
@@ -2572,13 +2722,13 @@ int SyncMechanism::ll_populate_prev_stat_and_prev_inode() {
   if (create_fresh || (purge_remote && cur_entry->prev_d_type != -1)) {
     return 0;
   }
-  if (cur_entry->fh.ll_info.p_inode == nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.p_parent_inode.back() != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.p_info.parent != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.p_info.parent->inode != nullptr);
+  if (cur_entry->fh.ll_info.p_info.inode == nullptr) {
     r = replayer->ll_open_inode(
-        fh.p_mnt, cur_entry->fh.ll_info.p_parent_inode.back(),
-        cur_entry->fh.ll_info.p_path, cur_entry->fh.ll_info.p_inode,
-        cur_entry->pstx, (cur_entry->pstat_known ? 0 : mask),
-        fh.ll_info.p_perms);
+        fh.p_mnt, cur_entry->fh.ll_info.p_info, cur_entry->pstx,
+        (cur_entry->pstat_known ? 0 : mask), fh.ll_info.p_perms);
+    ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
     if (r < 0 && r != -ENOENT) {
       derr << ": failed to do low level openning of diff base's cur entry= "
            << (fh.p_mnt == replayer->m_local_mount
@@ -2589,9 +2739,10 @@ int SyncMechanism::ll_populate_prev_stat_and_prev_inode() {
       return r;
     }
   } else if (!cur_entry->pstat_known) {
-    r = ceph_ll_getattr(
-        fh.p_mnt, cur_entry->fh.ll_info.p_inode.get(), &cur_entry->pstx, mask,
-        replayer->sync_flags, fh.ll_info.p_perms);
+    ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
+    r = ceph_ll_getattr(fh.p_mnt, cur_entry->fh.ll_info.p_info.inode.get(),
+                        &cur_entry->pstx, mask, replayer->sync_flags,
+                        fh.ll_info.p_perms);
     if (r < 0 && r != -ENOENT) {
       derr << ": failed to gather low level stat of diff base's cur entry= "
            << (fh.p_mnt == replayer->m_local_mount
@@ -2656,6 +2807,9 @@ void LL_DeleteMechanism::finish(int r) {
     goto notify_finish;
   }
   r = ll_cleanup_remote_entry();
+  if (r < 0) {
+    registry->set_failed(r);
+  }
 notify_finish:
   registry->dec_sync_indicator();
 }
@@ -2825,32 +2979,47 @@ bool DirSyncMechanism::try_spawning(SyncMechanism *syncm) {
 
 void PeerReplayer::SyncEntry::rollout(FHandles &parent_fh,
                                       const std::string &ename) {
-  if (parent_fh.ll_info.c_inode != nullptr) {
-    fh.ll_info.c_parent_inode = parent_fh.ll_info.c_parent_inode;
-    fh.ll_info.c_parent_inode.push_back(parent_fh.ll_info.c_inode);
-    fh.ll_info.c_path = ename;
+  ceph_assert(parent_fh.ll_info.c_info.parent != nullptr);
+  ceph_assert(parent_fh.ll_info.c_info.parent->inode != nullptr);
+  ceph_assert(parent_fh.ll_info.p_info.parent != nullptr);
+  ceph_assert(parent_fh.ll_info.p_info.parent->inode != nullptr);
+  ceph_assert(parent_fh.ll_info.r_info.parent != nullptr);
+  ceph_assert(parent_fh.ll_info.r_info.parent->inode != nullptr);
+  if (parent_fh.ll_info.c_info.inode != nullptr) {
+    ceph_assert(!parent_fh.ll_info.c_info.gap);
+    fh.ll_info.c_info.parent = std::make_shared<AncestorsLink>(
+        parent_fh.ll_info.c_info.parent, parent_fh.ll_info.c_info.inode);
+    fh.ll_info.c_info.gap = false;
+    fh.ll_info.c_info.path = ename;
   } else {
-    ceph_assert(parent_fh.ll_info.c_parent_inode.back() != nullptr);
-    fh.ll_info.c_parent_inode = parent_fh.ll_info.c_parent_inode;
-    fh.ll_info.c_path = std::move(entry_path(parent_fh.ll_info.c_path, ename));
+    fh.ll_info.c_info.parent = parent_fh.ll_info.c_info.parent;
+    fh.ll_info.c_info.gap = true;
+    fh.ll_info.c_info.path =
+        std::move(entry_path(parent_fh.ll_info.c_info.path, ename));
   }
-  if (parent_fh.ll_info.p_inode != nullptr) {
-    fh.ll_info.p_parent_inode = parent_fh.ll_info.p_parent_inode;
-    fh.ll_info.p_parent_inode.push_back(parent_fh.ll_info.p_inode);
-    fh.ll_info.p_path = ename;
+  if (parent_fh.ll_info.p_info.inode != nullptr) {
+    ceph_assert(!parent_fh.ll_info.p_info.gap);
+    fh.ll_info.p_info.parent = std::make_shared<AncestorsLink>(
+        parent_fh.ll_info.p_info.parent, parent_fh.ll_info.p_info.inode);
+    fh.ll_info.p_info.gap = false;
+    fh.ll_info.p_info.path = ename;
   } else {
-    ceph_assert(parent_fh.ll_info.p_parent_inode.back() != nullptr);
-    fh.ll_info.p_parent_inode = parent_fh.ll_info.p_parent_inode;
-    fh.ll_info.p_path = std::move(entry_path(parent_fh.ll_info.p_path, ename));
+    fh.ll_info.p_info.parent = parent_fh.ll_info.p_info.parent;
+    fh.ll_info.p_info.gap = true;
+    fh.ll_info.p_info.path =
+        std::move(entry_path(parent_fh.ll_info.p_info.path, ename));
   }
-  if (parent_fh.ll_info.r_inode != nullptr) {
-    fh.ll_info.r_parent_inode = parent_fh.ll_info.r_parent_inode;
-    fh.ll_info.r_parent_inode.push_back(parent_fh.ll_info.r_inode);
-    fh.ll_info.r_path = ename;
+  if (parent_fh.ll_info.r_info.inode != nullptr) {
+    ceph_assert(!parent_fh.ll_info.r_info.gap);
+    fh.ll_info.r_info.parent = std::make_shared<AncestorsLink>(
+        parent_fh.ll_info.r_info.parent, parent_fh.ll_info.r_info.inode);
+    fh.ll_info.r_info.gap = false;
+    fh.ll_info.r_info.path = ename;
   } else {
-    ceph_assert(parent_fh.ll_info.r_parent_inode.back() != nullptr);
-    fh.ll_info.r_parent_inode = parent_fh.ll_info.r_parent_inode;
-    fh.ll_info.r_path = std::move(entry_path(parent_fh.ll_info.r_path, ename));
+    fh.ll_info.r_info.parent = parent_fh.ll_info.r_info.parent;
+    fh.ll_info.r_info.gap = true;
+    fh.ll_info.r_info.path =
+        std::move(entry_path(parent_fh.ll_info.r_info.path, ename));
   }
 }
 
@@ -3090,10 +3259,7 @@ int DirSnapDiffSync::ll_sync_current_entry() {
       cur_entry->purge_remote() || (need_data_sync && failed_prev)) {
     SyncMechanism *syncm = nullptr;
     if (failed_prev) {
-      cur_entry->fh.ll_info.p_parent_inode =
-          cur_entry->fh.ll_info.r_parent_inode;
-      cur_entry->fh.ll_info.p_inode = cur_entry->fh.ll_info.r_inode;
-      cur_entry->fh.ll_info.p_path = cur_entry->fh.ll_info.r_path;
+      cur_entry->fh.ll_info.p_info = cur_entry->fh.ll_info.r_info;
       cur_entry->change_mask = 0;     // we need to re-calculate for remote
       cur_entry->pstat_known = false; // we need to re-calculate for remote
       cur_entry->prev_d_type = -1;    // we need to re-calculate for remote
@@ -3127,11 +3293,11 @@ int DirSnapDiffSync::ll_sync_current_entry() {
     cur_entry = nullptr;
     return 0;
   }
-  ceph_assert(cur_entry->fh.ll_info.p_inode != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.p_info.inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
   r = ceph_ll_open_snapdiff(replayer->m_local_mount,
-                            cur_entry->fh.ll_info.p_inode.get(),
-                            cur_entry->fh.ll_info.c_inode.get(),
+                            cur_entry->fh.ll_info.p_info.inode.get(),
+                            cur_entry->fh.ll_info.c_info.inode.get(),
                             &cur_entry->info, replayer->m_local_perms);
 
   if (r != 0) {
@@ -3322,12 +3488,12 @@ int DirBruteDiffSync::ll_go_next() {
     d_entry->stat_known = true;
     d_entry->rollout(entry->fh, e_name);
     ceph_assert(c_inode_raw != nullptr);
-    d_entry->fh.ll_info.c_inode =
+    d_entry->fh.ll_info.c_info.inode =
         create_inode_shared_ptr(replayer->m_local_mount, c_inode_raw);
     if (!entry->create_fresh() && !entry->purge_remote()) {
       auto it = entry->cache_map.find(e_name);
       if (it != entry->cache_map.end()) {
-        d_entry->fh.ll_info.p_inode = std::move(it->second.p_inode);
+        d_entry->fh.ll_info.p_info.inode = std::move(it->second.p_inode);
         d_entry->pstx = it->second.pstx;
         d_entry->pstat_known = true;
         d_entry->prev_d_type =
@@ -3478,9 +3644,7 @@ int DirBruteDiffSync::ll_sync_current_entry() {
   if (failed_prev && fh.p_mnt == replayer->m_local_mount &&
       (cur_entry->create_fresh() || cur_entry->purge_remote() ||
        need_data_sync)) {
-    cur_entry->fh.ll_info.p_parent_inode = cur_entry->fh.ll_info.r_parent_inode;
-    cur_entry->fh.ll_info.p_inode = cur_entry->fh.ll_info.r_inode;
-    cur_entry->fh.ll_info.p_path = cur_entry->fh.ll_info.r_path;
+    cur_entry->fh.ll_info.p_info = cur_entry->fh.ll_info.r_info;
     cur_entry->change_mask = 0;     // we need to re-calculate for remote
     cur_entry->pstat_known = false; // we need to re-calculate for remote
     cur_entry->prev_d_type = -1;    // we need to re-calculate for remote
@@ -3492,11 +3656,14 @@ int DirBruteDiffSync::ll_sync_current_entry() {
     return 0;
   }
 
+  ll_populate_remote_inode_with_diff_base();
+
   if (cur_entry->purge_remote()) {
     SyncMechanism *syncm = new LL_DeleteMechanism(
         replayer->m_local_mount, cur_entry, registry, sync_stat, fh, replayer);
     registry->sync_pool->sync_direct(syncm, local_stat);
     cur_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
+    cur_entry->fh.ll_info.r_info.inode = nullptr;
   }
 
   if (cur_entry->create_fresh()) {
@@ -3532,10 +3699,10 @@ int DirBruteDiffSync::ll_sync_current_entry() {
     cur_entry = nullptr;
     return 0;
   }
-  ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
   r = replayer->ll_open_dirp(replayer->m_local_mount,
-                             cur_entry->fh.ll_info.c_inode, cur_entry->udirp,
-                             replayer->m_local_perms);
+                             cur_entry->fh.ll_info.c_info.inode,
+                             cur_entry->udirp, replayer->m_local_perms);
   if (r < 0) {
     derr << ": failed to do low level opendir of cur snapshot's cur entry="
          << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
@@ -3695,7 +3862,7 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
                                     const Snapshot &current,
                                     boost::optional<Snapshot> prev) {
   dout(0)
-      << "cephfs_mirror_file_sync_thread="
+      << ": cephfs_mirror_file_sync_thread="
       << g_ceph_context->_conf.get_val<uint64_t>(
              "cephfs_mirror_file_sync_thread")
       << ", cephfs_mirror_dir_scanning_thread=" << dir_scanning_thread
@@ -3746,7 +3913,7 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
          << ": " << cpp_strerror(r) << dendl;
     return r;
   }
-  if (registry->snapdiff_fh.ll_info.p_parent_inode.back() == nullptr) {
+  if (registry->snapdiff_fh.ll_info.p_info.inode == nullptr) {
     r = set_snap_id_attr(dir_root, "ceph.mirror.diff_base", 0);
     if (r < 0) {
       return r;
@@ -3771,14 +3938,13 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
   SyncMechanism *syncm = nullptr;
   std::shared_ptr<SyncEntry> cur_entry =
       std::make_shared<SyncEntry>("");
-  cur_entry->fh =
-      (registry->snapdiff_fh.ll_info.p_parent_inode.back() == nullptr)
-          ? registry->remotediff_fh
-          : registry->snapdiff_fh;
+  cur_entry->fh = (registry->snapdiff_fh.ll_info.p_info.inode == nullptr)
+                      ? registry->remotediff_fh
+                      : registry->snapdiff_fh;
 
   std::shared_ptr <SyncEntry> root_entry = cur_entry;
 
-  if (registry->snapdiff_fh.ll_info.p_parent_inode.back() != nullptr) {
+  if (registry->snapdiff_fh.ll_info.p_info.inode != nullptr) {
     if (use_snapdiff_api) {
       sync_stat->current_stat.set_diff_base("ll_local_snapdiff_diff_base_" +
                                             (*prev).first);
@@ -3825,7 +3991,7 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
 int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &current,
                                  boost::optional<Snapshot> prev) {
   dout(0)
-      << "cephfs_mirror_file_sync_thread="
+      << ":cephfs_mirror_file_sync_thread="
       << g_ceph_context->_conf.get_val<uint64_t>(
              "cephfs_mirror_file_sync_thread")
       << ", cephfs_mirror_dir_scanning_thread=" << dir_scanning_thread

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -964,15 +964,16 @@ int PeerReplayer::_remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
 }
 
 int SyncMechanism::ll_remote_mkdir() {
-  ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
   ceph_assert(cur_entry->fh.ll_info.r_inode == nullptr);
   int r = 0;
   InodeRawPtr raw_inode = nullptr;
   struct ceph_statx rstx;
-  r = ceph_ll_mkdir(
-      replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
-      cur_entry->fh.ll_info.r_path.c_str(), cur_entry->stx.stx_mode & ~S_IFDIR,
-      &raw_inode, &rstx, 0, replayer->sync_flags, replayer->m_remote_perms);
+  r = ceph_ll_mkdir(replayer->m_remote_mount,
+                    cur_entry->fh.ll_info.r_parent_inode.back().get(),
+                    cur_entry->fh.ll_info.r_path.c_str(),
+                    cur_entry->stx.stx_mode & ~S_IFDIR, &raw_inode, &rstx, 0,
+                    replayer->sync_flags, replayer->m_remote_perms);
   if (r < 0) {
     return r;
   }
@@ -980,7 +981,7 @@ int SyncMechanism::ll_remote_mkdir() {
   cur_entry->fh.ll_info.r_inode =
       create_inode_shared_ptr(replayer->m_remote_mount, raw_inode);
   sync_stat->current_stat.inc_dir_created_count();
-  dout(0) << ": --->" << cur_entry->epath << dendl;
+  // dout(0) << ": --->" << cur_entry->epath << dendl;
   return 0;
 }
 
@@ -1008,6 +1009,7 @@ int PeerReplayer::remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
 #define NR_IOVECS 4 // # iovecs
 #define IOVEC_SIZE (1024 * 1024) // buffer size for each iovec
 int FileSyncMechanism::ll_copy_to_remote() {
+  // dout(0) << ": 1--->" << cur_entry->epath << dendl;
   uint64_t total_read = 0, total_wrote = 0;
   int r = 0;
   file_worker->state = FileMirrorPool::FileWorker::ThreadState::BACKOFF_CHECK1;
@@ -1017,6 +1019,8 @@ int FileSyncMechanism::ll_copy_to_remote() {
   file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_OPEN_LOCAL;
   FhRawPtr fh_raw = nullptr;
   ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+  // dout(0) << ": --->" << cur_entry->epath
+  //         << ", in=" << cur_entry->fh.ll_info.c_inode.get() << dendl;
   r = ceph_ll_open(replayer->m_local_mount, cur_entry->fh.ll_info.c_inode.get(),
                    O_RDONLY | O_NOFOLLOW, &fh_raw, replayer->m_local_perms);
   if (r < 0) {
@@ -1036,13 +1040,14 @@ int FileSyncMechanism::ll_copy_to_remote() {
     ll_populate_remote_inode_with_diff_base();
   }
   if (cur_entry->fh.ll_info.r_inode == nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
     InodeRawPtr inode_raw = nullptr;
-    r = ceph_ll_create(
-        replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
-        cur_entry->fh.ll_info.r_path.c_str(), cur_entry->stx.stx_mode,
-        O_CREAT | O_WRONLY | O_NOFOLLOW, &inode_raw, &fh_raw, &rstx, 0,
-        replayer->sync_flags, replayer->m_remote_perms);
+    r = ceph_ll_create(replayer->m_remote_mount,
+                       cur_entry->fh.ll_info.r_parent_inode.back().get(),
+                       cur_entry->fh.ll_info.r_path.c_str(),
+                       cur_entry->stx.stx_mode, O_CREAT | O_WRONLY | O_NOFOLLOW,
+                       &inode_raw, &fh_raw, &rstx, 0, replayer->sync_flags,
+                       replayer->m_remote_perms);
     if (r < 0) {
       derr << ": failed to create remote file path="
            << abs_path(registry->dir_root, cur_entry->epath) << ": "
@@ -1136,7 +1141,7 @@ int FileSyncMechanism::ll_copy_to_remote() {
   sync_stat->current_stat.inc_file_data_synced_count(cur_entry->stx.stx_size);
 free_ptr:
   free(ptr);
-  dout(0) << ": --->" << cur_entry->epath << dendl;
+  // dout(0) << ": 2--->" << cur_entry->epath << dendl;
   return (r < 0 ? r : 0);
 }
 int PeerReplayer::copy_to_remote(std::shared_ptr<SyncEntry> &cur_entry,
@@ -1274,10 +1279,11 @@ void PeerReplayer::enqueue_file_transfer(
 }
 
 int SyncMechanism::ll_unlink_cur_file_entry() {
-  ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
-  int r = ceph_ll_unlink(
-      replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
-      cur_entry->fh.ll_info.r_path.c_str(), replayer->m_remote_perms);
+  ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
+  int r = ceph_ll_unlink(replayer->m_remote_mount,
+                         cur_entry->fh.ll_info.r_parent_inode.back().get(),
+                         cur_entry->fh.ll_info.r_path.c_str(),
+                         replayer->m_remote_perms);
   if (r < 0 && r != -ENOENT) {
     return r;
   }
@@ -1286,15 +1292,16 @@ int SyncMechanism::ll_unlink_cur_file_entry() {
     cur_entry->fh.ll_info.p_inode = nullptr;
   }
   sync_stat->current_stat.inc_file_del_count();
-  dout(0) << ": --->" << cur_entry->epath << dendl;
+  // dout(0) << ": --->" << cur_entry->epath << dendl;
   return 0;
 }
 
 int SyncMechanism::ll_unlink_cur_dir_entry() {
-  ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
-  int r = ceph_ll_rmdir(
-      replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
-      cur_entry->fh.ll_info.r_path.c_str(), replayer->m_remote_perms);
+  ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
+  int r = ceph_ll_rmdir(replayer->m_remote_mount,
+                        cur_entry->fh.ll_info.r_parent_inode.back().get(),
+                        cur_entry->fh.ll_info.r_path.c_str(),
+                        replayer->m_remote_perms);
   if (r < 0 && r != -ENOENT) {
     return r;
   }
@@ -1302,7 +1309,7 @@ int SyncMechanism::ll_unlink_cur_dir_entry() {
   if (fh.p_mnt == replayer->m_remote_mount) {
     cur_entry->fh.ll_info.p_inode = nullptr;
   }
-  dout(0) << ": --->" << cur_entry->epath << dendl;
+  // dout(0) << ": --->" << cur_entry->epath << dendl;
   sync_stat->current_stat.inc_dir_deleted_count();
   return 0;
 }
@@ -1310,11 +1317,11 @@ int SyncMechanism::ll_unlink_cur_dir_entry() {
 int SyncMechanism::ll_remote_file_op() {
   struct ceph_statx& cstx = cur_entry->stx;
   struct ceph_statx& pstx = cur_entry->pstx;
-  if (S_ISREG(cstx.stx_mode)) {
-    dout(0) << ": file--->" << cur_entry->epath << dendl;
-  } else if (S_ISLNK(cstx.stx_mode)) {
-    dout(0) << ": link--->" << cur_entry->epath << dendl;
-  }
+  // if (S_ISREG(cstx.stx_mode)) {
+  //   dout(0) << ": file--->" << cur_entry->epath << dendl;
+  // } else if (S_ISLNK(cstx.stx_mode)) {
+  //   dout(0) << ": link--->" << cur_entry->epath << dendl;
+  // }
   bool need_data_sync =
       cur_entry->create_fresh() || cur_entry->purge_remote() ||
       (cstx.stx_mtime != pstx.stx_mtime) || (cstx.stx_size != pstx.stx_size);
@@ -1354,10 +1361,11 @@ int SyncMechanism::ll_remote_file_op() {
       struct ceph_statx rstx;
       InodeRawPtr link_raw = nullptr;
       target[cstx.stx_size] = '\0';
-      r = ceph_ll_symlink(
-          replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
-          cur_entry->fh.ll_info.r_path.c_str(), target, &link_raw, &rstx, 0,
-          replayer->sync_flags, replayer->m_remote_perms);
+      r = ceph_ll_symlink(replayer->m_remote_mount,
+                          cur_entry->fh.ll_info.r_parent_inode.back().get(),
+                          cur_entry->fh.ll_info.r_path.c_str(), target,
+                          &link_raw, &rstx, 0, replayer->sync_flags,
+                          replayer->m_remote_perms);
 
       if (r < 0 && r != -EEXIST) {
         derr << ": failed to do low level symlink on remote cur entry="
@@ -1464,9 +1472,9 @@ int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
 }
 
 int SyncMechanism::ll_cleanup_remote_entry() {
-  dout(0) << ": --->" << cur_entry->epath << dendl;
+  // dout(0) << ": --->" << cur_entry->epath << dendl;
   int r = 0;
-  ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
   if (cur_entry->prev_d_type != DT_DIR) {
     r = ll_unlink_cur_file_entry();
     if (r == 0) {
@@ -1781,7 +1789,7 @@ int PeerReplayer::should_sync_entry(const std::string &epath, const struct ceph_
 }
 
 int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
-  dout(0) << ": --->" << cur_entry->epath << dendl;
+  // dout(0) << ": --->" << cur_entry->epath << dendl;
   ceph_assert(cur_entry->fh.ll_info.p_inode != nullptr);
   ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
   int r = 0;
@@ -2064,10 +2072,12 @@ int PeerReplayer::ll_pre_sync_check_and_open_registry_inodes(
   std::size_t pos = dir_root.find_first_not_of('/');
   std::string cur_path = (pos == std::string::npos ? "." : dir_root.substr(pos));
   auto cur_snap_path = snapshot_path(m_cct, cur_path, current.first);
+
   struct ceph_statx stx;
+
   int r = ll_open_inode(m_local_mount, m_local_root_inode, cur_snap_path,
-                        registry->remotediff_fh.ll_info.c_parent_inode, stx, 0,
-                        m_local_perms);
+                        registry->remotediff_fh.ll_info.c_parent_inode.back(),
+                        stx, 0, m_local_perms);
 
   if (r < 0) {
     derr << ": error occurred while doing low level opening of local inode of "
@@ -2084,8 +2094,8 @@ int PeerReplayer::ll_pre_sync_check_and_open_registry_inodes(
   if (prev) {
     auto prev_snap_path = snapshot_path(m_cct, cur_path, (*prev).first);
     r = ll_open_inode(m_local_mount, m_local_root_inode, prev_snap_path,
-                      registry->snapdiff_fh.ll_info.p_parent_inode, stx, 0,
-                      m_local_perms);
+                      registry->snapdiff_fh.ll_info.p_parent_inode.back(), stx,
+                      0, m_local_perms);
     if (r < 0) {
       derr << ": error occurred while doing low level opening of local inode "
               "of dir="
@@ -2095,8 +2105,8 @@ int PeerReplayer::ll_pre_sync_check_and_open_registry_inodes(
     registry->snapdiff_fh.ll_info.p_perms = m_local_perms;
   }
   r = ll_open_inode(m_remote_mount, m_remote_root_inode, cur_path,
-                    registry->remotediff_fh.ll_info.r_parent_inode, stx, 0,
-                    m_remote_perms);
+                    registry->remotediff_fh.ll_info.r_parent_inode.back(), stx,
+                    0, m_remote_perms);
   if (r < 0) {
     derr << ": error occurred while opening remote low level inode of dir="
          << dir_root << " : " << cpp_strerror(r) << dendl;
@@ -2110,17 +2120,17 @@ int PeerReplayer::ll_pre_sync_check_and_open_registry_inodes(
   registry->remotediff_fh.ll_info.p_perms = m_remote_perms;
 
   registry->snapdiff_fh.ll_info.c_inode =
-      registry->snapdiff_fh.ll_info.c_parent_inode;
+      registry->snapdiff_fh.ll_info.c_parent_inode.back();
   registry->snapdiff_fh.ll_info.p_inode =
-      registry->snapdiff_fh.ll_info.p_parent_inode;
+      registry->snapdiff_fh.ll_info.p_parent_inode.back();
   registry->snapdiff_fh.ll_info.r_inode =
-      registry->snapdiff_fh.ll_info.r_parent_inode;
+      registry->snapdiff_fh.ll_info.r_parent_inode.back();
   registry->remotediff_fh.ll_info.c_inode =
-      registry->remotediff_fh.ll_info.c_parent_inode;
+      registry->remotediff_fh.ll_info.c_parent_inode.back();
   registry->remotediff_fh.ll_info.p_inode =
-      registry->remotediff_fh.ll_info.p_parent_inode;
+      registry->remotediff_fh.ll_info.p_parent_inode.back();
   registry->remotediff_fh.ll_info.r_inode =
-      registry->remotediff_fh.ll_info.r_parent_inode;
+      registry->remotediff_fh.ll_info.r_parent_inode.back();
   return 0;
 }
 
@@ -2378,7 +2388,7 @@ void PeerReplayer::DirSyncPool::update_qlimit(int _qlimit) {
 bool SyncMechanism::ll_populate_remote_inode_with_diff_base() {
   if (fh.p_mnt == replayer->m_remote_mount &&
       cur_entry->fh.ll_info.p_inode != nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.p_parent_inode != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.p_parent_inode.back() != nullptr);
     cur_entry->fh.ll_info.r_parent_inode = cur_entry->fh.ll_info.p_parent_inode;
     cur_entry->fh.ll_info.r_inode = cur_entry->fh.ll_info.p_inode;
     cur_entry->fh.ll_info.r_path = cur_entry->fh.ll_info.p_path;
@@ -2390,14 +2400,14 @@ bool SyncMechanism::ll_populate_remote_inode_with_diff_base() {
 int SyncMechanism::ll_populate_remote_inode() {
   int r = 0;
   if (cur_entry->fh.ll_info.r_inode != nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
     return 0;
   }
-  if (!ll_populate_remote_inode_with_diff_base()){
-    ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+  if (!ll_populate_remote_inode_with_diff_base()) {
+    ceph_assert(cur_entry->fh.ll_info.r_parent_inode.back() != nullptr);
     struct ceph_statx rstx;
     r = replayer->ll_open_inode(
-        replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode,
+        replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.back(),
         cur_entry->fh.ll_info.r_path, cur_entry->fh.ll_info.r_inode, rstx, 0,
         replayer->m_remote_perms);
     if (r < 0) {
@@ -2468,19 +2478,19 @@ int SyncMechanism::ll_update_remote_stat() {
   } else {
     sync_stat->current_stat.inc_dir_attr_synced_count();
   }
-  dout(0) << ": --->" << cur_entry->epath << dendl;
+  // dout(0) << ": --->" << cur_entry->epath << dendl;
   return 0;
 }
 
 int SyncMechanism::ll_populate_cur_stat_and_cur_inode() {
-  dout(0) << ": 1--->" << cur_entry->epath << dendl;
+  // dout(0) << ": 1--->" << cur_entry->epath << dendl;
   int r = 0;
   int mask = CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
              CEPH_STATX_SIZE | CEPH_STATX_MTIME;
   if (cur_entry->fh.ll_info.c_inode == nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.c_parent_inode != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.c_parent_inode.back() != nullptr);
     r = replayer->ll_open_inode(
-        replayer->m_local_mount, cur_entry->fh.ll_info.c_parent_inode,
+        replayer->m_local_mount, cur_entry->fh.ll_info.c_parent_inode.back(),
         cur_entry->fh.ll_info.c_path, cur_entry->fh.ll_info.c_inode,
         cur_entry->stx, (cur_entry->stat_known ? 0 : mask),
         replayer->m_local_perms);
@@ -2505,7 +2515,7 @@ int SyncMechanism::ll_populate_cur_stat_and_cur_inode() {
     }
   }
   cur_entry->stat_known = true;
-  dout(0) << ": 2--->" << cur_entry->epath << dendl;
+  // dout(0) << ": 2--->" << cur_entry->epath << dendl;
   return 0;
 }
 
@@ -2536,19 +2546,19 @@ int SyncMechanism::ll_populate_prev_stat_and_prev_inode() {
   bool create_fresh = cur_entry->create_fresh();
   int mask = CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
              CEPH_STATX_SIZE | CEPH_STATX_MTIME;
-  dout(0) << ": 1--->" << cur_entry->epath << ", purge_remote=" << purge_remote
-          << ", create_fresh=" << create_fresh << dendl;
+  // dout(0) << ": 1--->" << cur_entry->epath << ", purge_remote=" << purge_remote
+  //         << ", create_fresh=" << create_fresh << dendl;
 
   if (create_fresh || (purge_remote && cur_entry->prev_d_type != -1)) {
     return 0;
   }
   if (cur_entry->fh.ll_info.p_inode == nullptr) {
-    ceph_assert(cur_entry->fh.ll_info.p_parent_inode != nullptr);
-    r = replayer->ll_open_inode(fh.p_mnt, cur_entry->fh.ll_info.p_parent_inode,
-                                cur_entry->fh.ll_info.p_path,
-                                cur_entry->fh.ll_info.p_inode, cur_entry->pstx,
-                                (cur_entry->pstat_known ? 0 : mask),
-                                fh.ll_info.p_perms);
+    ceph_assert(cur_entry->fh.ll_info.p_parent_inode.back() != nullptr);
+    r = replayer->ll_open_inode(
+        fh.p_mnt, cur_entry->fh.ll_info.p_parent_inode.back(),
+        cur_entry->fh.ll_info.p_path, cur_entry->fh.ll_info.p_inode,
+        cur_entry->pstx, (cur_entry->pstat_known ? 0 : mask),
+        fh.ll_info.p_perms);
     if (r < 0 && r != -ENOENT) {
       derr << ": failed to do low level openning of diff base's cur entry= "
            << (fh.p_mnt == replayer->m_local_mount
@@ -2587,8 +2597,8 @@ int SyncMechanism::ll_populate_prev_stat_and_prev_inode() {
                       : ((!S_ISDIR(cur_entry->pstx.stx_mode)) ? (int)DT_REG
                                                               : (int)DT_DIR));
   cur_entry->pstat_known = true;
-  dout(0) << ": 2--->" << cur_entry->epath << ", purge_remote=" << purge_remote
-          << ", create_fresh=" << create_fresh << dendl;
+  // dout(0) << ": 2--->" << cur_entry->epath << ", purge_remote=" << purge_remote
+  //         << ", create_fresh=" << create_fresh << dendl;
   return 0;
 }
 
@@ -2662,10 +2672,10 @@ notify_finish:
 int FileSyncMechanism::ll_sync_file() {
   int r = ll_copy_to_remote();
   if (r < 0) {
-    derr << ": failed to copy cur entry="
-         << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
-                     replayer->m_cct)
-         << ": " << cpp_strerror(r) << dendl;
+    // derr << ": failed to copy cur entry="
+    //      << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+    //                  replayer->m_cct)
+    //      << ": " << cpp_strerror(r) << dendl;
     return r;
   }
   return 0;
@@ -2795,28 +2805,31 @@ bool DirSyncMechanism::try_spawning(SyncMechanism *syncm) {
 }
 
 void PeerReplayer::SyncEntry::rollout(FHandles &parent_fh,
-                                               const std::string &ename) {
+                                      const std::string &ename) {
   if (parent_fh.ll_info.c_inode != nullptr) {
-    fh.ll_info.c_parent_inode = parent_fh.ll_info.c_inode;
+    fh.ll_info.c_parent_inode = parent_fh.ll_info.c_parent_inode;
+    fh.ll_info.c_parent_inode.push_back(parent_fh.ll_info.c_inode);
     fh.ll_info.c_path = ename;
   } else {
-    ceph_assert(parent_fh.ll_info.c_parent_inode != nullptr);
+    ceph_assert(parent_fh.ll_info.c_parent_inode.back() != nullptr);
     fh.ll_info.c_parent_inode = parent_fh.ll_info.c_parent_inode;
     fh.ll_info.c_path = std::move(entry_path(parent_fh.ll_info.c_path, ename));
   }
   if (parent_fh.ll_info.p_inode != nullptr) {
-    fh.ll_info.p_parent_inode = parent_fh.ll_info.p_inode;
+    fh.ll_info.p_parent_inode = parent_fh.ll_info.p_parent_inode;
+    fh.ll_info.p_parent_inode.push_back(parent_fh.ll_info.p_inode);
     fh.ll_info.p_path = ename;
   } else {
-    ceph_assert(parent_fh.ll_info.p_parent_inode != nullptr);
+    ceph_assert(parent_fh.ll_info.p_parent_inode.back() != nullptr);
     fh.ll_info.p_parent_inode = parent_fh.ll_info.p_parent_inode;
     fh.ll_info.p_path = std::move(entry_path(parent_fh.ll_info.p_path, ename));
   }
   if (parent_fh.ll_info.r_inode != nullptr) {
-    fh.ll_info.r_parent_inode = parent_fh.ll_info.r_inode;
+    fh.ll_info.r_parent_inode = parent_fh.ll_info.r_parent_inode;
+    fh.ll_info.r_parent_inode.push_back(parent_fh.ll_info.r_inode);
     fh.ll_info.r_path = ename;
   } else {
-    ceph_assert(parent_fh.ll_info.r_parent_inode != nullptr);
+    ceph_assert(parent_fh.ll_info.r_parent_inode.back() != nullptr);
     fh.ll_info.r_parent_inode = parent_fh.ll_info.r_parent_inode;
     fh.ll_info.r_path = std::move(entry_path(parent_fh.ll_info.r_path, ename));
   }
@@ -3022,7 +3035,7 @@ int DirSnapDiffSync::go_next() {
 }
 
 int DirSnapDiffSync::ll_sync_current_entry() {
-  dout(0) << ": --->" << cur_entry->epath << dendl;
+  // dout(0) << ": --->" << cur_entry->epath << dendl;
   ceph_assert(fh.p_mnt == replayer->m_local_mount);
   int r = 0;
   bool failed_prev =
@@ -3402,9 +3415,9 @@ int DirBruteDiffSync::go_next() {
 }
 
 int DirBruteDiffSync::ll_sync_current_entry() {
-  dout(0) << ": --->" << cur_entry->epath << ", "
-          << ((fh.p_mnt == replayer->m_remote_mount) ? "remote" : "local")
-          << dendl;
+  // dout(0) << ": --->" << cur_entry->epath << ", "
+  //         << ((fh.p_mnt == replayer->m_remote_mount) ? "remote" : "local")
+  //         << dendl;
   int r = 0;
   bool failed_prev =
       (sync_stat->synced_snap_count == 0 || sync_stat->nr_failures > 0);
@@ -3685,6 +3698,8 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
       << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
       << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
       << dendl;
+  // ceph_assert(sync_flags == AT_SYMLINK_NOFOLLOW);
+  // sync_flags = AT_SYMLINK_NOFOLLOW;
 
   dout(0) << ": sync start-->" << dir_root << ",cur_snap= " << current.first
           << ", diff_base=" << (prev ? (*prev).first : "remote") << dendl;
@@ -3703,7 +3718,7 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
          << ": " << cpp_strerror(r) << dendl;
     return r;
   }
-  if (registry->snapdiff_fh.ll_info.p_parent_inode == nullptr) {
+  if (registry->snapdiff_fh.ll_info.p_parent_inode.back() == nullptr) {
     r = set_snap_id_attr(dir_root, "ceph.mirror.diff_base", 0);
     if (r < 0) {
       return r;
@@ -3728,13 +3743,14 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
   SyncMechanism *syncm = nullptr;
   std::shared_ptr<SyncEntry> cur_entry =
       std::make_shared<SyncEntry>("");
-  cur_entry->fh = (registry->snapdiff_fh.ll_info.p_parent_inode == nullptr)
-                           ? registry->remotediff_fh
-                           : registry->snapdiff_fh;
+  cur_entry->fh =
+      (registry->snapdiff_fh.ll_info.p_parent_inode.back() == nullptr)
+          ? registry->remotediff_fh
+          : registry->snapdiff_fh;
 
   std::shared_ptr <SyncEntry> root_entry = cur_entry;
 
-  if (registry->snapdiff_fh.ll_info.p_parent_inode != nullptr) {
+  if (registry->snapdiff_fh.ll_info.p_parent_inode.back() != nullptr) {
     if (use_snapdiff_api) {
       sync_stat->current_stat.set_diff_base("ll_local_snapdiff_diff_base_" +
                                             (*prev).first);
@@ -3771,6 +3787,7 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
   registry->file_sync_queue_idx = -2;
   registry->sync_pool->deactivate();
   registry->sync_pool = nullptr;
+  // sync_stat->reset_stats(r);
   lock.unlock();
   dout(0) << ": sync done-->" << dir_root << ", " << current.first << dendl;
   return r;

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -64,11 +64,27 @@ std::string snapshot_path(const std::string &snap_dir, const std::string &snap_n
 }
 
 std::string snapshot_path(CephContext *cct, const std::string &path, const std::string &snap_name) {
+  if (path == "/" || path.empty()) {
+    return "/" + cct->_conf->client_snapdir + "/" + snap_name;
+  }
   return path + "/" + cct->_conf->client_snapdir + "/" + snap_name;
 }
 
 std::string entry_path(const std::string &dir, const std::string &name) {
+  if (dir == "") {
+    return name;
+  }
   return dir + "/" + name;
+}
+
+std::string abs_path(const std::string &cur_dir, const std::string &rel_path) {
+  return cur_dir + "/" + rel_path;
+}
+
+std::string abs_path(const std::string &cur_dir, const std::string &rel_path,
+                     const std::string &snap_name, CephContext *cct) {
+  return (cur_dir + "/" + cct->_conf->client_snapdir + "/" + snap_name + "/" +
+          rel_path);
 }
 
 std::map<std::string, std::string> decode_snap_metadata(snap_metadata *snap_metadata,
@@ -121,6 +137,28 @@ int opendirat(MountRef mnt, int dirfd, const std::string &relpath, int flags,
     ceph_close(mnt, fd);
   }
   return r;
+}
+
+inline InodeSharedPtr create_inode_shared_ptr(MountRef cmount,
+                                              InodeRawPtr inode) {
+  if (!inode) {
+    return InodeSharedPtr();
+  }
+  return InodeSharedPtr(inode, InodeDeleter{cmount});
+}
+
+inline DirUniquePtr create_dirp_unique_ptr(MountRef cmount, DirRawPtr dirp) {
+  if (!dirp) {
+    return DirUniquePtr();
+  }
+  return DirUniquePtr(dirp, DirResultDeleter{cmount});
+}
+
+inline FhUniquePtr create_fh_unique_ptr(MountRef cmount, FhRawPtr fh) {
+  if (!fh) {
+    return FhUniquePtr();
+  }
+  return FhUniquePtr(fh, FhDeleter{cmount});
 }
 
 } // anonymous namespace
@@ -222,12 +260,32 @@ PeerReplayer::PeerReplayer(
       "cephfs_mirror_thread_pool_queue_size");
   max_element_in_cache_per_thread = g_ceph_context->_conf.get_val<uint64_t>(
       "cephfs_mirror_max_element_in_cache_per_thread");
-  sync_latest_snapshot = g_ceph_context->_conf.get_val<bool>(
-      "cephfs_mirror_sync_latest_snapshot");
+  sync_latest_snapshot =
+      g_ceph_context->_conf.get_val<bool>("cephfs_mirror_sync_latest_snapshot");
   remote_diff_base_upon_start = g_ceph_context->_conf.get_val<bool>(
       "cephfs_mirror_remote_diff_base_upon_start");
   start_syncing =
       g_ceph_context->_conf.get_val<bool>("cephfs_mirror_start_syncing");
+  max_concurrent_directory_syncs = g_ceph_context->_conf.get_val<uint64_t>(
+      "cephfs_mirror_max_concurrent_directory_syncs");
+  use_snapdiff_api =
+      g_ceph_context->_conf.get_val<bool>("cephfs_mirror_use_snapdiff_api");
+  lock_directory_before_sync = g_ceph_context->_conf.get_val<bool>(
+      "cephfs_mirror_lock_directory_before_sync");
+  remote_timeout =
+      g_ceph_context->_conf.get_val<uint64_t>("cephfs_mirror_remote_timeout");
+  local_timeout =
+      g_ceph_context->_conf.get_val<uint64_t>("cephfs_mirror_local_timeout");
+  max_consecutive_failures_before_remote_sync =
+      g_ceph_context->_conf.get_val<uint64_t>(
+          "cephfs_mirror_max_consecutive_failures_before_remote_sync");
+  skip_error = g_ceph_context->_conf.get_val<bool>("cephfs_mirror_skip_error");
+  use_low_level_api =
+      g_ceph_context->_conf.get_val<bool>("cephfs_mirror_use_low_level_api");
+  use_at_statx_dont_sync = g_ceph_context->_conf.get_val<bool>(
+      "cephfs_mirror_use_at_statx_dont_sync");
+  sync_flags =
+      (use_at_statx_dont_sync ? AT_STATX_DONT_SYNC : 0) | AT_SYMLINK_NOFOLLOW;
 }
 
 PeerReplayer::~PeerReplayer() {
@@ -360,6 +418,16 @@ void PeerReplayer::handle_conf_change(const ConfigProxy &conf,
     skip_error =
         g_ceph_context->_conf.get_val<bool>("cephfs_mirror_skip_error");
   }
+  if (changed.count("cephfs_mirror_use_low_level_api")) {
+    use_low_level_api =
+        g_ceph_context->_conf.get_val<bool>("cephfs_mirror_use_low_level_api");
+  }
+  if (changed.count("cephfs_mirror_use_at_statx_dont_sync")) {
+    use_at_statx_dont_sync = g_ceph_context->_conf.get_val<bool>(
+        "cephfs_mirror_use_at_statx_dont_sync");
+    sync_flags =
+        (use_at_statx_dont_sync ? AT_STATX_DONT_SYNC : 0) | AT_SYMLINK_NOFOLLOW;
+  }
 
   m_cond.notify_all();
   dout(0)
@@ -393,7 +461,10 @@ void PeerReplayer::handle_conf_change(const ConfigProxy &conf,
       << ", client_cache_size=" << g_ceph_context->_conf->client_cache_size
       << ", cephfs_mirror_max_consecutive_failures_before_remote_sync="
       << max_consecutive_failures_before_remote_sync
-      << ", cephfs_mirror_skipp_error=" << skip_error << dendl;
+      << ", cephfs_mirror_skip_error=" << skip_error
+      << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
+      << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
+      << dendl;
 }
 
 const char **PeerReplayer::get_tracked_conf_keys() const {
@@ -409,6 +480,9 @@ const char **PeerReplayer::get_tracked_conf_keys() const {
                                "cephfs_mirror_remote_timeout",
                                "cephfs_mirror_local_timeout",
                                "cephfs_mirror_max_consecutive_failures_before_remote_sync",
+                               "cephfs_mirror_skip_error",
+                               "cephfs_mirror_use_low_level_api",
+                               "cephfs_mirror_use_at_statx_dont_sync",
                                NULL};
   return KEYS;
 }
@@ -475,6 +549,29 @@ int PeerReplayer::init() {
     derr << ": error mounting remote filesystem=" << remote_filesystem << dendl;
     return r;
   }
+
+  m_local_perms = ceph_mount_perms(m_local_mount);
+  m_remote_perms = ceph_mount_perms(m_remote_mount);
+
+  InodeRawPtr raw_ptr = nullptr;
+  r = ceph_ll_lookup_root(m_local_mount, &raw_ptr);
+  if (r < 0) {
+    derr
+        << ": error occurred while doing low level lookup on local root inode: "
+        << cpp_strerror(r) << dendl;
+    return r;
+  }
+  m_local_root_inode = create_inode_shared_ptr(m_local_mount, raw_ptr);
+
+  raw_ptr = nullptr;
+  r = ceph_ll_lookup_root(m_remote_mount, &raw_ptr);
+  if (r < 0) {
+    derr << ": error occurred while doing low level lookup on remote root "
+            "inode: "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+  m_remote_root_inode = create_inode_shared_ptr(m_remote_mount, raw_ptr);
 
   std::scoped_lock locker(m_lock);
   nr_replayers = max_concurrent_directory_syncs =
@@ -866,6 +963,27 @@ int PeerReplayer::_remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
   return 0;
 }
 
+int SyncMechanism::ll_remote_mkdir() {
+  ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.r_inode == nullptr);
+  int r = 0;
+  InodeRawPtr raw_inode = nullptr;
+  struct ceph_statx rstx;
+  r = ceph_ll_mkdir(
+      replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
+      cur_entry->fh.ll_info.r_path.c_str(), cur_entry->stx.stx_mode & ~S_IFDIR,
+      &raw_inode, &rstx, 0, replayer->sync_flags, replayer->m_remote_perms);
+  if (r < 0) {
+    return r;
+  }
+  ceph_assert(raw_inode != nullptr);
+  cur_entry->fh.ll_info.r_inode =
+      create_inode_shared_ptr(replayer->m_remote_mount, raw_inode);
+  sync_stat->current_stat.inc_dir_created_count();
+  dout(0) << ": --->" << cur_entry->epath << dendl;
+  return 0;
+}
+
 int PeerReplayer::remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
                                const FHandles &fh,
                                std::shared_ptr<SnapSyncStat> &sync_stat) {
@@ -887,8 +1005,140 @@ int PeerReplayer::remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
   return r;
 }
 
-#define NR_IOVECS 8 // # iovecs
-#define IOVEC_SIZE (8 * 1024 * 1024) // buffer size for each iovec
+#define NR_IOVECS 4 // # iovecs
+#define IOVEC_SIZE (1024 * 1024) // buffer size for each iovec
+int FileSyncMechanism::ll_copy_to_remote() {
+  uint64_t total_read = 0, total_wrote = 0;
+  int r = 0;
+  file_worker->state = FileMirrorPool::FileWorker::ThreadState::BACKOFF_CHECK1;
+  if (replayer->should_backoff(registry, &r)) {
+    return r;
+  }
+  file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_OPEN_LOCAL;
+  FhRawPtr fh_raw = nullptr;
+  ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+  r = ceph_ll_open(replayer->m_local_mount, cur_entry->fh.ll_info.c_inode.get(),
+                   O_RDONLY | O_NOFOLLOW, &fh_raw, replayer->m_local_perms);
+  if (r < 0) {
+    derr << ": failed to open cur snapshot's file path="
+         << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                     replayer->m_cct)
+         << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  ceph_assert(fh_raw != nullptr);
+  FhUniquePtr l_fh = create_fh_unique_ptr(replayer->m_local_mount, fh_raw);
+  file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_OPEN_REMOTE;
+
+  struct ceph_statx rstx;
+  fh_raw = nullptr;
+  if (cur_entry->fh.ll_info.r_inode == nullptr) {
+    ll_populate_remote_inode_with_diff_base();
+  }
+  if (cur_entry->fh.ll_info.r_inode == nullptr) {
+    ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+    InodeRawPtr inode_raw = nullptr;
+    r = ceph_ll_create(
+        replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
+        cur_entry->fh.ll_info.r_path.c_str(), cur_entry->stx.stx_mode,
+        O_CREAT | O_WRONLY | O_NOFOLLOW, &inode_raw, &fh_raw, &rstx, 0,
+        replayer->sync_flags, replayer->m_remote_perms);
+    if (r < 0) {
+      derr << ": failed to create remote file path="
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+    ceph_assert(inode_raw != nullptr);
+    cur_entry->fh.ll_info.r_inode =
+        create_inode_shared_ptr(replayer->m_remote_mount, inode_raw);
+  } else {
+    r = ceph_ll_open(replayer->m_remote_mount,
+                     cur_entry->fh.ll_info.r_inode.get(), O_WRONLY | O_NOFOLLOW,
+                     &fh_raw, replayer->m_remote_perms);
+    if (r < 0) {
+      derr << ": failed to open remote file path="
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+  ceph_assert(fh_raw != nullptr);
+  FhUniquePtr r_fh = create_fh_unique_ptr(replayer->m_remote_mount, fh_raw);
+  void *ptr = malloc(NR_IOVECS * IOVEC_SIZE);
+  if (!ptr) {
+    derr << ": failed to allocate memory for remote file="
+         << abs_path(registry->dir_root, cur_entry->epath) << dendl;
+    return -ENOMEM;
+  }
+  struct iovec iov[NR_IOVECS];
+  while (true) {
+    r = 0;
+    file_worker->state = FileMirrorPool::FileWorker::ThreadState::BACKOFF_CHECK2;
+    if (replayer->should_backoff(registry, &r)) {
+      break;
+    }
+    for (int i = 0; i < NR_IOVECS; ++i) {
+      iov[i].iov_base = (char *)ptr + IOVEC_SIZE * i;
+      iov[i].iov_len = IOVEC_SIZE;
+    }
+    file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_READ;
+    r = ceph_ll_readv(replayer->m_local_mount, l_fh.get(), iov, NR_IOVECS, -1);
+    if (r < 0) {
+      derr << ": failed to read from local file="
+           << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                       replayer->m_cct)
+           << ": " << cpp_strerror(r) << dendl;
+      break;
+    }
+    if (r == 0) {
+      break;
+    }
+    total_read += r;
+    int iovs = (int)(r / IOVEC_SIZE);
+    int t = r % IOVEC_SIZE;
+    if (t) {
+      iov[iovs].iov_len = t;
+      ++iovs;
+    }
+    file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_WRITE;
+    r = ceph_ll_writev(replayer->m_remote_mount, r_fh.get(), iov, iovs, -1);
+    if (r < 0) {
+      derr << ": failed to write into remote file="
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      break;
+    }
+    total_wrote += r;
+    file_worker->bytes_synced = total_wrote;
+  }
+  if (r < 0) {
+    goto free_ptr;
+  }
+  file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_FTRUNC;
+  r = ll_update_remote_stat();
+  if (r < 0) {
+    derr << ": failed to populate low level stat of remote cur entry"
+            "entry= "
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    goto free_ptr;
+  }
+
+  file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_FSYNC;
+  r = ceph_ll_fsync(replayer->m_remote_mount, r_fh.get(), 0);
+  if (r < 0) {
+    derr << ": failed to sync remote file path="
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    goto free_ptr;
+  }
+  sync_stat->current_stat.inc_file_data_synced_count(cur_entry->stx.stx_size);
+free_ptr:
+  free(ptr);
+  dout(0) << ": --->" << cur_entry->epath << dendl;
+  return (r < 0 ? r : 0);
+}
 int PeerReplayer::copy_to_remote(std::shared_ptr<SyncEntry> &cur_entry,
                                  DirRegistry *registry, const FHandles &fh,
                                  FileMirrorPool::FileWorker *file_worker) {
@@ -1023,6 +1273,123 @@ void PeerReplayer::enqueue_file_transfer(
   file_mirror_pool.sync_file_data(syncm, registry->get_file_sync_queue_idx());
 }
 
+int SyncMechanism::ll_unlink_cur_file_entry() {
+  ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+  int r = ceph_ll_unlink(
+      replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
+      cur_entry->fh.ll_info.r_path.c_str(), replayer->m_remote_perms);
+  if (r < 0 && r != -ENOENT) {
+    return r;
+  }
+  cur_entry->fh.ll_info.r_inode = nullptr;
+  if (fh.p_mnt == replayer->m_remote_mount) {
+    cur_entry->fh.ll_info.p_inode = nullptr;
+  }
+  sync_stat->current_stat.inc_file_del_count();
+  dout(0) << ": --->" << cur_entry->epath << dendl;
+  return 0;
+}
+
+int SyncMechanism::ll_unlink_cur_dir_entry() {
+  ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+  int r = ceph_ll_rmdir(
+      replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
+      cur_entry->fh.ll_info.r_path.c_str(), replayer->m_remote_perms);
+  if (r < 0 && r != -ENOENT) {
+    return r;
+  }
+  cur_entry->fh.ll_info.r_inode = nullptr;
+  if (fh.p_mnt == replayer->m_remote_mount) {
+    cur_entry->fh.ll_info.p_inode = nullptr;
+  }
+  dout(0) << ": --->" << cur_entry->epath << dendl;
+  sync_stat->current_stat.inc_dir_deleted_count();
+  return 0;
+}
+
+int SyncMechanism::ll_remote_file_op() {
+  struct ceph_statx& cstx = cur_entry->stx;
+  struct ceph_statx& pstx = cur_entry->pstx;
+  if (S_ISREG(cstx.stx_mode)) {
+    dout(0) << ": file--->" << cur_entry->epath << dendl;
+  } else if (S_ISLNK(cstx.stx_mode)) {
+    dout(0) << ": link--->" << cur_entry->epath << dendl;
+  }
+  bool need_data_sync =
+      cur_entry->create_fresh() || cur_entry->purge_remote() ||
+      (cstx.stx_mtime != pstx.stx_mtime) || (cstx.stx_size != pstx.stx_size);
+
+  dout(10) << ": dir_root=" << registry->dir_root
+           << ", epath=" << cur_entry->epath
+           << ", need_data_sync=" << need_data_sync << dendl;
+  int r = 0;
+  if (need_data_sync) {
+    if (S_ISREG(cstx.stx_mode)) {
+      FileSyncMechanism *syncm =
+          new FileSyncMechanism(replayer->m_local_mount, std::move(cur_entry),
+                                registry, sync_stat, fh, replayer);
+      replayer->enqueue_file_transfer(syncm, registry, sync_stat);
+      return 0;
+    } else if (S_ISLNK(cstx.stx_mode)) {
+      r = ll_unlink_cur_file_entry();
+      if (r < 0) {
+        derr << "failed to do low level unlink of remote symlink cur entry="
+             << abs_path(registry->dir_root, cur_entry->epath) << ": "
+             << cpp_strerror(r) << dendl;
+        return r;
+      }
+      char *target = (char *)alloca(cstx.stx_size + 1);
+      ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+      r = ceph_ll_readlink(replayer->m_local_mount,
+                           cur_entry->fh.ll_info.c_inode.get(), target,
+                           cstx.stx_size, replayer->m_local_perms);
+      if (r < 0) {
+        derr << "failed to do low level readlink of local current snapshot's "
+                "cur entry="
+             << abs_path(registry->dir_root, cur_entry->epath,
+                         fh.m_current.first, replayer->m_cct)
+             << ": " << cpp_strerror(r) << dendl;
+        return r;
+      }
+      struct ceph_statx rstx;
+      InodeRawPtr link_raw = nullptr;
+      target[cstx.stx_size] = '\0';
+      r = ceph_ll_symlink(
+          replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode.get(),
+          cur_entry->fh.ll_info.r_path.c_str(), target, &link_raw, &rstx, 0,
+          replayer->sync_flags, replayer->m_remote_perms);
+
+      if (r < 0 && r != -EEXIST) {
+        derr << ": failed to do low level symlink on remote cur entry="
+             << abs_path(registry->dir_root, cur_entry->epath) << ": "
+             << cpp_strerror(r) << dendl;
+        return r;
+      } else if (r == -EEXIST) {
+        cur_entry->fh.ll_info.r_inode = nullptr;
+      } else {
+        ceph_assert(link_raw != nullptr);
+        cur_entry->fh.ll_info.r_inode =
+            create_inode_shared_ptr(replayer->m_remote_mount, link_raw);
+      }
+      cur_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
+      sync_stat->current_stat.inc_file_data_synced_count(cstx.stx_size);
+    } else {
+      dout(5) << ": skipping entry=" << cur_entry->epath
+              << ": unsupported mode=" << cstx.stx_mode << dendl;
+      return 0;
+    }
+  }
+  r = ll_update_remote_stat();
+  if (r < 0) {
+    derr << ": failed to populate low level stat of remote cur entry"
+            "entry= "
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+  return 0;
+}
+
 int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
                                  DirRegistry *registry,
                                  std::shared_ptr<SnapSyncStat> &sync_stat,
@@ -1088,11 +1455,117 @@ int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
     return r;
   }
   if (cur_entry->change_mask & all_change) {
-    sync_stat->current_stat.inc_files_synced(false, cur_entry->stx.stx_size);
+    sync_stat->current_stat.inc_file_attr_synced_count();
   } else {
     sync_stat->current_stat.inc_file_skipped_count();
   }
   
+  return 0;
+}
+
+int SyncMechanism::ll_cleanup_remote_entry() {
+  dout(0) << ": --->" << cur_entry->epath << dendl;
+  int r = 0;
+  ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+  if (cur_entry->prev_d_type != DT_DIR) {
+    r = ll_unlink_cur_file_entry();
+    if (r == 0) {
+      return 0;
+    }
+    r = ll_populate_remote_inode();
+    if (r < 0 && r != -ENOENT) {
+      derr << ": failed to populate low level inode of remote cur entry="
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    } else if (r == -ENOENT) {
+      return 0;
+    }
+    ceph_assert(cur_entry->fh.ll_info.r_inode != nullptr);
+    r = replayer->ll_open_dirp(replayer->m_remote_mount,
+                               cur_entry->fh.ll_info.r_inode, cur_entry->udirp,
+                               replayer->m_remote_perms);
+    if (r < 0 && r != -ENOENT) {
+      derr << ": failed to open low level inode of remote cur entry="
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    } else if (r == -ENOENT) {
+      return 0;
+    }
+  } else {
+    r = ll_populate_remote_inode();
+    if (r == -ENOENT) {
+      return 0;
+    } else if (r < 0) {
+      r = ll_unlink_cur_file_entry();
+      if (r < 0) {
+        derr << "failed to do low level unlink of remote cur entry="
+             << abs_path(registry->dir_root, cur_entry->epath) << ": "
+             << cpp_strerror(r) << dendl;
+        return r;
+      }
+      return 0;
+    }
+    ceph_assert(cur_entry->fh.ll_info.r_inode != nullptr);
+    r = replayer->ll_open_dirp(replayer->m_remote_mount,
+                               cur_entry->fh.ll_info.r_inode, cur_entry->udirp,
+                               replayer->m_remote_perms);
+    if (r == -ENOENT) {
+      return 0;
+    } else if (r < 0) {
+      r = ll_unlink_cur_file_entry();
+      if (r < 0) {
+        derr << "failed to do low level unlink of remote cur entry="
+             << abs_path(registry->dir_root, cur_entry->epath) << ": "
+             << cpp_strerror(r) << dendl;
+        return r;
+      }
+      return 0;
+    }
+  }
+  struct dirent de;
+  struct ceph_statx rstx;
+  while (true) {
+    if (replayer->should_backoff(registry, &r)) {
+      return r;
+    }
+    InodeRawPtr r_inode_raw = nullptr;
+    r = ceph_readdirplus_r(replayer->m_remote_mount, cur_entry->udirp.get(),
+                           &de, &rstx, 0, replayer->sync_flags, &r_inode_raw);
+    if (r < 0) {
+      derr << ": failed to read remote cur entry="
+           << abs_path(registry->dir_root, cur_entry->epath) << dendl;
+      return r;
+    }
+    if (r == 0) {
+      break;
+    }
+    auto d_name = std::string(de.d_name);
+    if (d_name == "." || d_name == "..") {
+      continue;
+    }
+    std::shared_ptr<PeerReplayer::SyncEntry> d_entry =
+        std::make_shared<PeerReplayer::SyncEntry>(
+            std::move(entry_path(cur_entry->epath, d_name)));
+    d_entry->rollout(cur_entry->fh, d_name);
+    d_entry->prev_d_type = (int)de.d_type;
+    ceph_assert(r_inode_raw != nullptr);
+    d_entry->fh.ll_info.r_inode =
+        create_inode_shared_ptr(replayer->m_remote_mount, r_inode_raw);
+    SyncMechanism *syncm =
+        new LL_DeleteMechanism(replayer->m_local_mount, std::move(d_entry),
+                               registry, sync_stat, fh, replayer);
+    registry->sync_pool->sync_direct(syncm);
+  }
+
+  r = ll_unlink_cur_dir_entry();
+  if (r < 0) {
+    derr << "failed to do low level unlink of remote dir cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
   return 0;
 }
 
@@ -1130,7 +1603,7 @@ int PeerReplayer::cleanup_remote_entry(const std::string &epath,
   r = ceph_statxat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), &tstx,
                    CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                        CEPH_STATX_SIZE | CEPH_STATX_MTIME,
-                   AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                   sync_flags);
   if (r == -ENOENT) {
     dout(10) << ": entry already removed=" << epath << dendl;
     return r;
@@ -1183,7 +1656,7 @@ int PeerReplayer::cleanup_remote_entry(const std::string &epath,
       while (true) {
         r = ceph_readdirplus_r(m_remote_mount, entry.dirp, &de, &stx,
                               CEPH_STATX_MODE,
-                              AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
+                              sync_flags, NULL);
         if (r < 0) {
           derr << ": failed to read remote directory=" << entry.epath << dendl;
           break;
@@ -1273,7 +1746,7 @@ int PeerReplayer::should_sync_entry(const std::string &epath, const struct ceph_
   int r = ceph_statxat(fh.p_mnt, fh.p_fd, epath.c_str(), &pstx,
                        CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                        CEPH_STATX_SIZE | CEPH_STATX_CTIME | CEPH_STATX_MTIME,
-                       AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                       sync_flags);
   if (r < 0 && r != -ENOENT && r != -ENOTDIR) {
     derr << ": failed to stat prev entry= " << epath << ": " << cpp_strerror(r)
          << dendl;
@@ -1304,6 +1777,96 @@ int PeerReplayer::should_sync_entry(const std::string &epath, const struct ceph_
     *need_attr_sync = (cstx.stx_ctime != pstx.stx_ctime);
   }
 
+  return 0;
+}
+
+int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
+  dout(0) << ": --->" << cur_entry->epath << dendl;
+  ceph_assert(cur_entry->fh.ll_info.p_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+  int r = 0;
+  DirUniquePtr udirp;
+  r = replayer->ll_open_dirp(fh.p_mnt, cur_entry->fh.ll_info.p_inode, udirp,
+                             fh.ll_info.p_perms);
+  if (r < 0) {
+    if (r == -ELOOP || r == -ENOTDIR || r == -ENOENT) {
+      return 0;
+    }
+    return r;
+  }
+
+  struct dirent de;
+  struct ceph_statx pstx, cstx;
+  while (true) {
+    unsigned int extra_flags =
+        (cache_size < replayer->max_element_in_cache_per_thread)
+            ? (CEPH_STATX_UID | CEPH_STATX_GID | CEPH_STATX_SIZE |
+               CEPH_STATX_MTIME)
+            : 0;
+    InodeRawPtr p_inode_raw = nullptr;
+    r = ceph_readdirplus_r(
+        fh.p_mnt, udirp.get(), &de, &pstx, extra_flags | CEPH_STATX_MODE,
+        replayer->sync_flags, &p_inode_raw);
+    if (r < 0) {
+      derr << ": failed to read dir of diff base's cur entry="
+           << (fh.p_mnt == replayer->m_remote_mount
+                   ? abs_path(registry->dir_root, cur_entry->epath)
+                   : abs_path(registry->dir_root, cur_entry->epath,
+                              (*fh.m_prev).first, replayer->m_cct))
+           << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    if (r == 0) {
+      break;
+    }
+    std::string d_name = de.d_name;
+    if (d_name == "." || d_name == "..") {
+      continue;
+    }
+    ceph_assert(p_inode_raw != nullptr);
+    InodeSharedPtr p_inode = create_inode_shared_ptr(fh.p_mnt, p_inode_raw);
+    std::string epath = std::move(entry_path(cur_entry->epath, d_name));
+    InodeSharedPtr c_inode = nullptr;
+    r = replayer->ll_open_inode(
+        replayer->m_local_mount, cur_entry->fh.ll_info.c_inode, d_name, c_inode,
+        cstx, extra_flags | CEPH_STATX_MODE, replayer->m_local_perms);
+    if (r < 0 && r != -ENOENT) {
+      derr << ": failed to do low level openning of cur snapshot's cur entry="
+           << abs_path(registry->dir_root, epath, fh.m_current.first,
+                       replayer->m_cct)
+           << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    bool purge_remote = true;
+    bool entry_present = false;
+    if (r == 0) {
+      entry_present = true;
+      if ((pstx.stx_mode & S_IFMT) == (cstx.stx_mode & S_IFMT)) {
+        dout(5) << ": mode matches for entry=" << d_name << dendl;
+        purge_remote = false;
+      } else {
+        dout(5) << ": mode mismatch for entry=" << d_name << dendl;
+      }
+    } else {
+      dout(5) << ": entry=" << d_name << " missing in current snapshot"
+              << dendl;
+    }
+    if (purge_remote && !entry_present) {
+      std::shared_ptr<PeerReplayer::SyncEntry> d_entry =
+          std::make_shared<PeerReplayer::SyncEntry>(std::move(epath));
+      d_entry->rollout(cur_entry->fh, d_name);
+      d_entry->prev_d_type = (int)de.d_type;
+      d_entry->fh.ll_info.p_inode = std::move(p_inode);
+      SyncMechanism *syncm =
+          new LL_DeleteMechanism(replayer->m_local_mount, std::move(d_entry),
+                                 registry, sync_stat, fh, replayer);
+      registry->sync_pool->sync_anyway(syncm);
+    } else if (extra_flags) {
+      cur_entry->cache_map[d_name] =
+          PeerReplayer::CacheInfo(std::move(p_inode), pstx);
+      ++cache_size;
+    }
+  }
   return 0;
 }
 
@@ -1347,7 +1910,7 @@ int PeerReplayer::propagate_deleted_entries(
             : 0;
     r = ceph_readdirplus_r(fh.p_mnt, dirp, &de, &pstx,
                            CEPH_STATX_MODE | extra_flags,
-                           AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
+                           sync_flags, NULL);
 
     if (r < 0) {
       derr << ": failed to read directory entries: " << cpp_strerror(r)
@@ -1372,7 +1935,7 @@ int PeerReplayer::propagate_deleted_entries(
     struct ceph_statx cstx;
     r = ceph_statxat(m_local_mount, fh.c_fd, dpath.c_str(), &cstx,
                      CEPH_STATX_MODE | extra_flags,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                     sync_flags);
     if (r < 0 && r != -ENOENT) {
       derr << ": failed to stat local (cur) directory=" << dpath << ": "
            << cpp_strerror(r) << dendl;
@@ -1421,6 +1984,39 @@ int PeerReplayer::propagate_deleted_entries(
   return r;
 }
 
+int PeerReplayer::ll_open_inode(MountRef mnt, InodeSharedPtr &parent_inode,
+                                const std::string &dir_path,
+                                InodeSharedPtr &inode_shared,
+                                struct ceph_statx &stx, unsigned int want,
+                                UserPermRef perms) {
+  dout(20) << ": dir_path=" << dir_path << dendl;
+
+  InodeRawPtr inode = nullptr;
+  int r =
+      ceph_ll_lookup(mnt, parent_inode.get(), dir_path.c_str(), &inode, &stx,
+                     want, sync_flags, perms);
+  if (r < 0) {
+    inode = nullptr;
+  } else {
+    ceph_assert(inode != nullptr);
+  }
+  inode_shared = create_inode_shared_ptr(mnt, inode);
+  return (r < 0 ? r : 0);
+}
+
+int PeerReplayer::ll_open_dirp(MountRef mnt, InodeSharedPtr &inode,
+                               DirUniquePtr &udirp, UserPermRef perms) {
+  DirRawPtr rdirp = nullptr;
+  int r = ceph_ll_opendir(mnt, inode.get(), &rdirp, perms);
+  if (r < 0) {
+    rdirp = nullptr;
+  } else {
+    ceph_assert(rdirp != nullptr);
+  }
+  udirp = create_dirp_unique_ptr(mnt, rdirp);
+  return (r < 0 ? r : 0);
+}
+
 int PeerReplayer::open_dir(MountRef mnt, const std::string &dir_path,
                            boost::optional<uint64_t> snap_id) {
   dout(20) << ": dir_path=" << dir_path << dendl;
@@ -1458,13 +2054,83 @@ int PeerReplayer::open_dir(MountRef mnt, const std::string &dir_path,
   return fd;
 }
 
+int PeerReplayer::ll_pre_sync_check_and_open_registry_inodes(
+    const std::string &dir_root, const Snapshot &current,
+    boost::optional<Snapshot> prev, DirRegistry *registry) {
+  dout(20) << ": dir_root=" << dir_root << ", current=" << current << dendl;
+  if (prev) {
+    dout(20) << ": dir_root=" << dir_root << ", prev=" << prev << dendl;
+  }
+  std::size_t pos = dir_root.find_first_not_of('/');
+  std::string cur_path = (pos == std::string::npos ? "." : dir_root.substr(pos));
+  auto cur_snap_path = snapshot_path(m_cct, cur_path, current.first);
+  struct ceph_statx stx;
+  int r = ll_open_inode(m_local_mount, m_local_root_inode, cur_snap_path,
+                        registry->remotediff_fh.ll_info.c_parent_inode, stx, 0,
+                        m_local_perms);
+
+  if (r < 0) {
+    derr << ": error occurred while doing low level opening of local inode of "
+            "dir="
+         << cur_snap_path << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  registry->snapdiff_fh.ll_info.c_parent_inode =
+      registry->remotediff_fh.ll_info.c_parent_inode;
+  registry->snapdiff_fh.m_current = current;
+  registry->remotediff_fh.m_current = current;
+  registry->snapdiff_fh.m_prev = prev;
+
+  if (prev) {
+    auto prev_snap_path = snapshot_path(m_cct, cur_path, (*prev).first);
+    r = ll_open_inode(m_local_mount, m_local_root_inode, prev_snap_path,
+                      registry->snapdiff_fh.ll_info.p_parent_inode, stx, 0,
+                      m_local_perms);
+    if (r < 0) {
+      derr << ": error occurred while doing low level opening of local inode "
+              "of dir="
+           << prev_snap_path << " : " << cpp_strerror(r) << dendl;
+    }
+    registry->snapdiff_fh.p_mnt = m_local_mount;
+    registry->snapdiff_fh.ll_info.p_perms = m_local_perms;
+  }
+  r = ll_open_inode(m_remote_mount, m_remote_root_inode, cur_path,
+                    registry->remotediff_fh.ll_info.r_parent_inode, stx, 0,
+                    m_remote_perms);
+  if (r < 0) {
+    derr << ": error occurred while opening remote low level inode of dir="
+         << dir_root << " : " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  registry->remotediff_fh.p_mnt = m_remote_mount;
+  registry->snapdiff_fh.ll_info.r_parent_inode =
+      registry->remotediff_fh.ll_info.p_parent_inode =
+          registry->remotediff_fh.ll_info.r_parent_inode;
+
+  registry->remotediff_fh.ll_info.p_perms = m_remote_perms;
+
+  registry->snapdiff_fh.ll_info.c_inode =
+      registry->snapdiff_fh.ll_info.c_parent_inode;
+  registry->snapdiff_fh.ll_info.p_inode =
+      registry->snapdiff_fh.ll_info.p_parent_inode;
+  registry->snapdiff_fh.ll_info.r_inode =
+      registry->snapdiff_fh.ll_info.r_parent_inode;
+  registry->remotediff_fh.ll_info.c_inode =
+      registry->remotediff_fh.ll_info.c_parent_inode;
+  registry->remotediff_fh.ll_info.p_inode =
+      registry->remotediff_fh.ll_info.p_parent_inode;
+  registry->remotediff_fh.ll_info.r_inode =
+      registry->remotediff_fh.ll_info.r_parent_inode;
+  return 0;
+}
+
 int PeerReplayer::pre_sync_check_and_open_handles(
     const std::string &dir_root,
     const Snapshot &current, boost::optional<Snapshot> prev,
     FHandles *snapdiff_fh, FHandles* remotediff_fh) {
   dout(20) << ": dir_root=" << dir_root << ", current=" << current << dendl;
   if (prev) {
-    dout(20) << ": prev=" << prev << dendl;
+    dout(20) << ": dir_root=" << dir_root << ", prev=" << prev << dendl;
   }
 
   auto cur_snap_path = snapshot_path(m_cct, dir_root, current.first);
@@ -1519,7 +2185,7 @@ int PeerReplayer::sync_perms(const std::string& path) {
   struct ceph_statx tstx;
 
   r = ceph_statx(m_local_mount, path.c_str(), &tstx, CEPH_STATX_MODE,
-		 AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+		 sync_flags);
   if (r < 0) {
     derr << ": failed to fetch stat for local path: "
 	 << cpp_strerror(r) << dendl;
@@ -1602,7 +2268,7 @@ void PeerReplayer::DirSyncPool::run(DirScanner *dir_scanner) {
       sync_queue.pop();
       queued--;
     }
-    task->complete(0);
+    task->complete(low_level);
   }
 }
 
@@ -1636,7 +2302,7 @@ void PeerReplayer::DirSyncPool::sync_anyway(SyncMechanism *task) {
 
 void PeerReplayer::DirSyncPool::sync_direct(SyncMechanism *task) {
   task->sync_in_flight();
-  task->complete(1);
+  task->complete(low_level);
 }
 
 void PeerReplayer::DirSyncPool::update_state(int thread_count) {
@@ -1709,6 +2375,140 @@ void PeerReplayer::DirSyncPool::update_qlimit(int _qlimit) {
   qlimit = _qlimit;
 }
 
+bool SyncMechanism::ll_populate_remote_inode_with_diff_base() {
+  if (fh.p_mnt == replayer->m_remote_mount &&
+      cur_entry->fh.ll_info.p_inode != nullptr) {
+    ceph_assert(cur_entry->fh.ll_info.p_parent_inode != nullptr);
+    cur_entry->fh.ll_info.r_parent_inode = cur_entry->fh.ll_info.p_parent_inode;
+    cur_entry->fh.ll_info.r_inode = cur_entry->fh.ll_info.p_inode;
+    cur_entry->fh.ll_info.r_path = cur_entry->fh.ll_info.p_path;
+    return true;
+  }
+  return false;
+}
+
+int SyncMechanism::ll_populate_remote_inode() {
+  int r = 0;
+  if (cur_entry->fh.ll_info.r_inode != nullptr) {
+    ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+    return 0;
+  }
+  if (!ll_populate_remote_inode_with_diff_base()){
+    ceph_assert(cur_entry->fh.ll_info.r_parent_inode != nullptr);
+    struct ceph_statx rstx;
+    r = replayer->ll_open_inode(
+        replayer->m_remote_mount, cur_entry->fh.ll_info.r_parent_inode,
+        cur_entry->fh.ll_info.r_path, cur_entry->fh.ll_info.r_inode, rstx, 0,
+        replayer->m_remote_perms);
+    if (r < 0) {
+      return r;
+    }
+  }
+  return 0;
+}
+
+int SyncMechanism::ll_update_remote_stat() {
+  int mask = 0, r = 0;
+  struct ceph_statx cstx = cur_entry->stx;
+  struct ceph_statx& pstx = cur_entry->pstx;
+
+  if (!cur_entry->create_fresh() && !cur_entry->purge_remote()) {
+    if ((cstx.stx_mode & ~S_IFMT) != (pstx.stx_mode & ~S_IFMT)) {
+      mask = mask | CEPH_SETATTR_MODE;
+    }
+    if (cstx.stx_size != pstx.stx_size && !S_ISDIR(cstx.stx_mode)) {
+      mask = mask | CEPH_SETATTR_SIZE;
+    }
+    if (cstx.stx_uid != pstx.stx_uid) {
+      mask = mask | CEPH_SETATTR_UID;
+    }
+    if (cstx.stx_gid != pstx.stx_gid) {
+      mask = mask | CEPH_SETATTR_GID;
+    }
+    if (cstx.stx_mtime != pstx.stx_mtime && !S_ISDIR(cstx.stx_mode)) {
+      mask = mask | CEPH_SETATTR_MTIME;
+    }
+  } else {
+    mask = CEPH_SETATTR_MODE | CEPH_SETATTR_UID | CEPH_SETATTR_GID;
+    if (!S_ISDIR(cstx.stx_mode)) {
+      mask |= (CEPH_SETATTR_MTIME | CEPH_SETATTR_SIZE);
+    }
+  }
+  if (S_ISDIR(cstx.stx_mode)) {
+    sync_stat->current_stat.inc_dir_scanned_count();
+  }
+  if (mask == 0) {
+    if (!S_ISDIR(cstx.stx_mode)) {
+      sync_stat->current_stat.inc_file_skipped_count();
+    }
+    return 0;
+  }
+
+  r = ll_populate_remote_inode();
+  if (r < 0) {
+    derr << ": failed to populate low level inode of remote cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  ceph_assert(cur_entry->fh.ll_info.r_inode != nullptr);
+  r = ceph_ll_setattr(replayer->m_remote_mount,
+                      cur_entry->fh.ll_info.r_inode.get(), &cstx, mask,
+                      replayer->m_remote_perms);
+
+  if (r < 0) {
+    derr << ": failed to do low level set attribute for remote cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath) << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+  if (!S_ISDIR(cur_entry->stx.stx_mode)) {
+    sync_stat->current_stat.inc_file_attr_synced_count();
+  } else {
+    sync_stat->current_stat.inc_dir_attr_synced_count();
+  }
+  dout(0) << ": --->" << cur_entry->epath << dendl;
+  return 0;
+}
+
+int SyncMechanism::ll_populate_cur_stat_and_cur_inode() {
+  dout(0) << ": 1--->" << cur_entry->epath << dendl;
+  int r = 0;
+  int mask = CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+             CEPH_STATX_SIZE | CEPH_STATX_MTIME;
+  if (cur_entry->fh.ll_info.c_inode == nullptr) {
+    ceph_assert(cur_entry->fh.ll_info.c_parent_inode != nullptr);
+    r = replayer->ll_open_inode(
+        replayer->m_local_mount, cur_entry->fh.ll_info.c_parent_inode,
+        cur_entry->fh.ll_info.c_path, cur_entry->fh.ll_info.c_inode,
+        cur_entry->stx, (cur_entry->stat_known ? 0 : mask),
+        replayer->m_local_perms);
+    if (r < 0) {
+      derr << ": failed to do low level opening of cur snapshot's cur entry= "
+           << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                       replayer->m_cct)
+           << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  } else if (!cur_entry->stat_known) {
+    r = ceph_ll_getattr(replayer->m_local_mount,
+                        cur_entry->fh.ll_info.c_inode.get(), &cur_entry->stx,
+                        mask, replayer->sync_flags,
+                        replayer->m_local_perms);
+    if (r < 0) {
+      derr << ": failed to gather low level stat of cur snapshot's cur entry= "
+           << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                       replayer->m_cct)
+           << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+  cur_entry->stat_known = true;
+  dout(0) << ": 2--->" << cur_entry->epath << dendl;
+  return 0;
+}
+
 int SyncMechanism::populate_current_stat(const PeerReplayer::FHandles &fh) {
   int r = 0;
   if (!cur_entry->stat_known) { // stat populated
@@ -1716,7 +2516,7 @@ int SyncMechanism::populate_current_stat(const PeerReplayer::FHandles &fh) {
                      &cur_entry->stx,
                      CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                          CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                     replayer->sync_flags);
     if (r < 0) {
       derr << ": failed to stat cur entry= " << cur_entry->epath << ": "
            << cpp_strerror(r) << dendl;
@@ -1726,7 +2526,70 @@ int SyncMechanism::populate_current_stat(const PeerReplayer::FHandles &fh) {
     }
     cur_entry->set_stat_known();
   }
+
   return r;
+}
+
+int SyncMechanism::ll_populate_prev_stat_and_prev_inode() {
+  int r = 0;
+  bool purge_remote = cur_entry->purge_remote();
+  bool create_fresh = cur_entry->create_fresh();
+  int mask = CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+             CEPH_STATX_SIZE | CEPH_STATX_MTIME;
+  dout(0) << ": 1--->" << cur_entry->epath << ", purge_remote=" << purge_remote
+          << ", create_fresh=" << create_fresh << dendl;
+
+  if (create_fresh || (purge_remote && cur_entry->prev_d_type != -1)) {
+    return 0;
+  }
+  if (cur_entry->fh.ll_info.p_inode == nullptr) {
+    ceph_assert(cur_entry->fh.ll_info.p_parent_inode != nullptr);
+    r = replayer->ll_open_inode(fh.p_mnt, cur_entry->fh.ll_info.p_parent_inode,
+                                cur_entry->fh.ll_info.p_path,
+                                cur_entry->fh.ll_info.p_inode, cur_entry->pstx,
+                                (cur_entry->pstat_known ? 0 : mask),
+                                fh.ll_info.p_perms);
+    if (r < 0 && r != -ENOENT) {
+      derr << ": failed to do low level openning of diff base's cur entry= "
+           << (fh.p_mnt == replayer->m_local_mount
+                   ? abs_path(registry->dir_root, cur_entry->epath,
+                              (*fh.m_prev).first, replayer->m_cct)
+                   : abs_path(registry->dir_root, cur_entry->epath))
+           << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  } else if (!cur_entry->pstat_known) {
+    r = ceph_ll_getattr(
+        fh.p_mnt, cur_entry->fh.ll_info.p_inode.get(), &cur_entry->pstx, mask,
+        replayer->sync_flags, fh.ll_info.p_perms);
+    if (r < 0 && r != -ENOENT) {
+      derr << ": failed to gather low level stat of diff base's cur entry= "
+           << (fh.p_mnt == replayer->m_local_mount
+                   ? abs_path(registry->dir_root, cur_entry->epath,
+                              (*fh.m_prev).first, replayer->m_cct)
+                   : abs_path(registry->dir_root, cur_entry->epath))
+           << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+  purge_remote = (r == 0 && (cur_entry->stx.stx_mode & S_IFMT) !=
+                                (cur_entry->pstx.stx_mode & S_IFMT));
+  create_fresh = (r == -ENOENT);
+  if (purge_remote) {
+    cur_entry->change_mask |= PeerReplayer::SyncEntry::PURGE_REMOTE;
+  }
+  if (create_fresh) {
+    cur_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
+  }
+
+  cur_entry->prev_d_type =
+      ((r == -ENOENT) ? -1
+                      : ((!S_ISDIR(cur_entry->pstx.stx_mode)) ? (int)DT_REG
+                                                              : (int)DT_DIR));
+  cur_entry->pstat_known = true;
+  dout(0) << ": 2--->" << cur_entry->epath << ", purge_remote=" << purge_remote
+          << ", create_fresh=" << create_fresh << dendl;
+  return 0;
 }
 
 int SyncMechanism::populate_change_mask(const PeerReplayer::FHandles &fh) {
@@ -1742,7 +2605,7 @@ int SyncMechanism::populate_change_mask(const PeerReplayer::FHandles &fh) {
         ceph_statxat(fh.p_mnt, fh.p_fd, cur_entry->epath.c_str(), &pstx,
                      CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                          CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                     replayer->sync_flags);
     if (pstat_r < 0 && pstat_r != -ENOENT && pstat_r != -ENOTDIR) {
       r = pstat_r;
       derr << ": failed to stat prev entry= " << cur_entry->epath << ": "
@@ -1756,6 +2619,15 @@ int SyncMechanism::populate_change_mask(const PeerReplayer::FHandles &fh) {
   replayer->build_change_mask(pstx, cur_entry->stx, create_fresh, purge_remote,
                               cur_entry->change_mask);
   return 0;
+}
+
+void LL_DeleteMechanism::finish(int r) {
+  if (r < 0) {
+    goto notify_finish;
+  }
+  r = ll_cleanup_remote_entry();
+notify_finish:
+  registry->dec_sync_indicator();
 }
 
 void DeleteMechanism::finish(int r) {
@@ -1774,16 +2646,29 @@ notify_finish:
 }
 
 void FileSyncMechanism::finish(int r) {
+  int x = 0;
   if (r < 0) {
     goto notify_finish;
   }
-  r = sync_file();
-  if (r < 0) {
-    registry->set_failed(r);
+  x = (r == 0) ? sync_file() : ll_sync_file();
+  if (x < 0) {
+    registry->set_failed(x);
   }
 notify_finish:
   sync_stat->current_stat.dec_file_in_flight_count();
   registry->dec_sync_indicator();
+}
+
+int FileSyncMechanism::ll_sync_file() {
+  int r = ll_copy_to_remote();
+  if (r < 0) {
+    derr << ": failed to copy cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                     replayer->m_cct)
+         << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  return 0;
 }
 
 int FileSyncMechanism::sync_file() {
@@ -1795,7 +2680,8 @@ int FileSyncMechanism::sync_file() {
     return r;
   }
   r = replayer->sync_attributes(cur_entry, fh);
-  sync_stat->current_stat.inc_files_synced(true, cur_entry->stx.stx_size);
+  sync_stat->current_stat.inc_file_data_synced_count(cur_entry->stx.stx_size);
+  sync_stat->current_stat.inc_file_attr_synced_count();
   return r;
 }
 
@@ -1837,36 +2723,65 @@ void PeerReplayer::build_change_mask(const struct ceph_statx &pstx,
 }
 
 void DirSyncMechanism::finish(int r) {
+  int x = 0;
   if (r < 0) {
     goto notify_finish;
   }
-  r = sync_tree();
-  if (r < 0) {
-    registry->set_failed(r);
+  x = (r == 0) ? sync_tree() : ll_sync_tree();
+  if (x < 0) {
+    registry->set_failed(x);
   }
 notify_finish:
   registry->dec_sync_indicator();
 }
 
+int DirSyncMechanism::ll_sync_tree() {
+  int r = 0, r1 = 0;
+  while (cur_entry && !replayer->should_backoff(registry, &r)) {
+    if (cur_entry->needs_remote_sync()) {
+      // **--> sync remote
+      r = ll_sync_current_entry();
+      if (r < 0) {
+        r1 = r;
+      }
+      if (!replayer->skip_error && r < 0) {
+        break;
+      }
+    }
+    r = ll_go_next();
+    if (r < 0) {
+      r1 = r;
+      break;
+    }
+  }
+finish:
+  ll_finish_sync();
+  return r1;
+}
+
 int DirSyncMechanism::sync_tree() {
 
-  int r = 0;
+  int r = 0, r1 = 0;
   while (cur_entry && !replayer->should_backoff(registry, &r)) {
     if (cur_entry->needs_remote_sync()) {
       // **--> sync remote
       r = sync_current_entry();
+      if (r < 0) {
+        r1 = r;
+      }
       if (!replayer->skip_error && r < 0) {
         break;
       }
     }
     r = go_next();
     if (r < 0) {
+      r1 = r;
       break;
     }
   }
 finish:
   finish_sync();
-  return r;
+  return r1;
 }
 
 bool DirSyncMechanism::try_spawning(SyncMechanism *syncm) {
@@ -1874,9 +2789,145 @@ bool DirSyncMechanism::try_spawning(SyncMechanism *syncm) {
     cur_entry = nullptr;
     return true;
   }
-  cur_entry = syncm->move_cur_entry();
+  cur_entry = std::move(syncm->cur_entry);
   delete syncm;
   return false;
+}
+
+void PeerReplayer::SyncEntry::rollout(FHandles &parent_fh,
+                                               const std::string &ename) {
+  if (parent_fh.ll_info.c_inode != nullptr) {
+    fh.ll_info.c_parent_inode = parent_fh.ll_info.c_inode;
+    fh.ll_info.c_path = ename;
+  } else {
+    ceph_assert(parent_fh.ll_info.c_parent_inode != nullptr);
+    fh.ll_info.c_parent_inode = parent_fh.ll_info.c_parent_inode;
+    fh.ll_info.c_path = std::move(entry_path(parent_fh.ll_info.c_path, ename));
+  }
+  if (parent_fh.ll_info.p_inode != nullptr) {
+    fh.ll_info.p_parent_inode = parent_fh.ll_info.p_inode;
+    fh.ll_info.p_path = ename;
+  } else {
+    ceph_assert(parent_fh.ll_info.p_parent_inode != nullptr);
+    fh.ll_info.p_parent_inode = parent_fh.ll_info.p_parent_inode;
+    fh.ll_info.p_path = std::move(entry_path(parent_fh.ll_info.p_path, ename));
+  }
+  if (parent_fh.ll_info.r_inode != nullptr) {
+    fh.ll_info.r_parent_inode = parent_fh.ll_info.r_inode;
+    fh.ll_info.r_path = ename;
+  } else {
+    ceph_assert(parent_fh.ll_info.r_parent_inode != nullptr);
+    fh.ll_info.r_parent_inode = parent_fh.ll_info.r_parent_inode;
+    fh.ll_info.r_path = std::move(entry_path(parent_fh.ll_info.r_path, ename));
+  }
+}
+
+int DirSnapDiffSync::ll_go_next() {
+  ceph_assert(fh.p_mnt == replayer->m_local_mount);
+  int r = 0;
+  while (!m_sync_stack.empty()) {
+    std::shared_ptr<PeerReplayer::SyncEntry> &entry = m_sync_stack.top();
+    dout(20) << ": top of stack path=" << entry->epath << dendl;
+    std::string e_name;
+    ceph_snapdiff_entry_t sd_entry;
+    bool failed = false;
+    while (true) {
+      r = 0;
+      if (replayer->should_backoff(registry, &r)) {
+        return r;
+      }
+      r = ceph_readdir_snapdiff(&entry->info, &sd_entry);
+      if (r < 0) {
+        derr << ": failed to read snapdiff entry between snapdiff of local "
+                "snapshot's cur entry="
+             << abs_path(registry->dir_root, entry->epath, fh.m_current.first,
+                         replayer->m_cct)
+             << "and diff base's cur entry="
+             << abs_path(registry->dir_root, entry->epath, (*fh.m_prev).first,
+                         replayer->m_cct)
+             << ": " << cpp_strerror(r) << dendl;
+        if (replayer->skip_error) {
+          registry->set_failed(r);
+          failed = true;
+          r = 0; break;
+        }
+        return r;
+      }
+      if (r == 0) {
+        break;
+      }
+      std::string d_name = sd_entry.dir_entry.d_name;
+      if (d_name == "." || d_name == "..") {
+        continue;
+      }
+      e_name = d_name;
+      break;
+    }
+    std::string epath = std::move(entry_path(entry->epath, e_name));
+
+    if (entry->deleted_sibling_exist && !failed) {
+      ceph_assert(entry->deleted_sibling.snapid == (*fh.m_prev).second);
+      std::string deleted_sibling_d_name =
+          entry->deleted_sibling.dir_entry.d_name;
+      if (r == 0 || sd_entry.snapid == (*fh.m_prev).second ||
+          e_name != deleted_sibling_d_name) {
+        std::shared_ptr<PeerReplayer::SyncEntry> deleted_entry =
+            std::make_shared<PeerReplayer::SyncEntry>(
+                std::move(entry_path(entry->epath, deleted_sibling_d_name)));
+        deleted_entry->rollout(entry->fh, deleted_sibling_d_name);
+        deleted_entry->prev_d_type =
+            (int)deleted_entry->deleted_sibling.dir_entry.d_type;
+        SyncMechanism *syncm = new LL_DeleteMechanism(
+            replayer->m_local_mount, std::move(deleted_entry), registry,
+            sync_stat, fh, replayer);
+        registry->sync_pool->sync_anyway(syncm);
+        entry->deleted_sibling_exist = false;
+      }
+    }
+    if (r == 0) {
+      dout(10) << ": done for directory=" << entry->epath << dendl;
+      r = ceph_close_snapdiff(&entry->info);
+      if (r < 0) {
+        derr << ": failed to close snapdiff info between snapdiff of local "
+                "snapshot's cur entry="
+             << abs_path(registry->dir_root, entry->epath, fh.m_current.first,
+                         replayer->m_cct)
+             << "and diff base's cur entry="
+             << abs_path(registry->dir_root, entry->epath, (*fh.m_prev).first,
+                         replayer->m_cct)
+             << ": " << cpp_strerror(r) << dendl;
+      }
+      r = 0;
+      m_sync_stack.pop();
+      continue;
+    }
+
+    if (sd_entry.snapid == (*fh.m_prev).second) {
+      entry->deleted_sibling = sd_entry;
+      entry->deleted_sibling_exist = true;
+      continue;
+    }
+    std::shared_ptr<PeerReplayer::SyncEntry> d_entry =
+        std::make_shared<PeerReplayer::SyncEntry>(std::move(epath));
+    d_entry->rollout(entry->fh, e_name);
+    if (entry->deleted_sibling_exist &&
+        sd_entry.snapid == fh.m_current.second &&
+        e_name == entry->deleted_sibling.dir_entry.d_name) {
+      ceph_assert(entry->deleted_sibling.snapid == (*fh.m_prev).second);
+      d_entry->change_mask |= PeerReplayer::SyncEntry::PURGE_REMOTE;
+      d_entry->prev_d_type = (int)entry->deleted_sibling.dir_entry.d_type;
+      entry->deleted_sibling_exist = false;
+    }
+    SyncMechanism *syncm =
+        new DirSnapDiffSync(replayer->m_local_mount, std::move(d_entry),
+                            registry, sync_stat, fh, replayer);
+    if (try_spawning(syncm)) {
+      continue;
+    }
+    r = 0;
+    break;
+  }
+  return 0;
 }
 
 int DirSnapDiffSync::go_next() {
@@ -1970,6 +3021,103 @@ int DirSnapDiffSync::go_next() {
   return r;
 }
 
+int DirSnapDiffSync::ll_sync_current_entry() {
+  dout(0) << ": --->" << cur_entry->epath << dendl;
+  ceph_assert(fh.p_mnt == replayer->m_local_mount);
+  int r = 0;
+  bool failed_prev =
+      (sync_stat->synced_snap_count == 0 || sync_stat->nr_failures > 0);
+
+  r = ll_populate_cur_stat_and_cur_inode();
+  if (r < 0) {
+    derr << ": failed to populate low level stat and inode of cur snapshot's "
+            "cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                     replayer->m_cct)
+         << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  r = ll_populate_prev_stat_and_prev_inode();
+  if (r < 0) {
+    derr << ": failed to populate low level stat and inode of diff base's cur "
+            "entry="
+         << abs_path(registry->dir_root, cur_entry->epath, (*fh.m_prev).first,
+                     replayer->m_cct)
+         << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  bool need_data_sync =
+      !S_ISDIR(cur_entry->stx.stx_mode) &&
+      (cur_entry->create_fresh() || cur_entry->purge_remote() ||
+       (cur_entry->stx.stx_mtime != cur_entry->pstx.stx_mtime) ||
+       (cur_entry->stx.stx_size != cur_entry->pstx.stx_size));
+
+  if ((S_ISDIR(cur_entry->stx.stx_mode) && cur_entry->create_fresh()) ||
+      cur_entry->purge_remote() || (need_data_sync && failed_prev)) {
+    SyncMechanism *syncm = nullptr;
+    if (failed_prev) {
+      cur_entry->fh.ll_info.p_parent_inode =
+          cur_entry->fh.ll_info.r_parent_inode;
+      cur_entry->fh.ll_info.p_inode = cur_entry->fh.ll_info.r_inode;
+      cur_entry->fh.ll_info.p_path = cur_entry->fh.ll_info.r_path;
+      cur_entry->change_mask = 0;     // we need to re-calculate for remote
+      cur_entry->pstat_known = false; // we need to re-calculate for remote
+      cur_entry->prev_d_type = -1;    // we need to re-calculate for remote
+    }
+    syncm = new DirBruteDiffSync(
+        replayer->m_local_mount, std::move(cur_entry), registry, sync_stat,
+        failed_prev ? registry->remotediff_fh : fh, replayer);
+    registry->sync_pool->sync_direct(syncm);
+    cur_entry = nullptr;
+    return 0;
+  }
+
+  if (S_ISDIR(cur_entry->stx.stx_mode)) {
+    r = ll_update_remote_stat();
+    if (r < 0) {
+      derr << ": failed to populate low level stat of remote cur entry"
+              "entry= "
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+  } else {
+    r = ll_remote_file_op();
+    if (r < 0) {
+      derr << ": failed to do low level remote file operation of remote cur "
+              "entry="
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+    cur_entry = nullptr;
+    return 0;
+  }
+
+  r = ceph_open_snapdiff(replayer->m_local_mount, registry->dir_root.c_str(),
+                         cur_entry->epath.c_str(), (*fh.m_prev).first.c_str(),
+                         fh.m_current.first.c_str(), &cur_entry->info);
+
+  if (r != 0) {
+    derr << ": failed to do low level openning of snapdiff between diff base's "
+            "cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath, (*fh.m_prev).first,
+                     replayer->m_cct)
+         << " and local cur snapshot's entry="
+         << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                     replayer->m_cct)
+         << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  cur_entry->is_snapdiff = true;
+  cur_entry->set_remote_synced();
+  m_sync_stack.emplace(std::move(cur_entry));
+  cur_entry = nullptr;
+  return 0;
+}
+
 int DirSnapDiffSync::sync_current_entry() {
   int r = 0;
   bool failed_prev =
@@ -2054,8 +3202,23 @@ int DirSnapDiffSync::sync_current_entry() {
   return 0;
 }
 
+void DirSnapDiffSync::ll_finish_sync() {
+  while (!m_sync_stack.empty()) {
+    auto &entry = m_sync_stack.top();
+    if (entry->is_snapdiff) {
+      int r = ceph_close_snapdiff(&(entry->info));
+      if (r < 0) {
+        derr << ": failed to close snapdiff for directory="
+             << abs_path(registry->dir_root, entry->epath, fh.m_current.first,
+                         replayer->m_cct)
+             << ": " << cpp_strerror(r) << dendl;
+      }
+    }
+    m_sync_stack.pop();
+  }
+}
+
 void DirSnapDiffSync::finish_sync() {
-  dout(20) << dendl;
 
   while (!m_sync_stack.empty()) {
     auto &entry = m_sync_stack.top();
@@ -2070,6 +3233,85 @@ void DirSnapDiffSync::finish_sync() {
 
     m_sync_stack.pop();
   }
+}
+
+int DirBruteDiffSync::ll_go_next() {
+  int r = 0;
+  while (!m_sync_stack.empty()) {
+    std::shared_ptr<PeerReplayer::SyncEntry> &entry = m_sync_stack.top();
+    std::string e_name;
+    struct ceph_statx stx;
+    struct dirent de;
+    InodeRawPtr c_inode_raw = nullptr;
+    while (true) {
+      if (replayer->should_backoff(registry, &r)) {
+        return r;
+      }
+      c_inode_raw = nullptr;
+      r = ceph_readdirplus_r(
+          replayer->m_local_mount, entry->udirp.get(), &de, &stx,
+          CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID | CEPH_STATX_SIZE |
+              CEPH_STATX_MTIME,
+          replayer->sync_flags, &c_inode_raw);
+      if (r < 0) {
+        derr << ": failed to read dir of local current snapshot's cur entry="
+             << abs_path(registry->dir_root, entry->epath, fh.m_current.first,
+                         replayer->m_cct)
+             << ": " << cpp_strerror(r) << dendl;
+        if (replayer->skip_error) {
+          registry->set_failed(r);
+          r = 0; break;
+        }
+        return r;
+      }
+      if (r == 0) {
+        break;
+      }
+      auto d_name = std::string(de.d_name);
+      if (d_name == "." || d_name == "..") {
+        continue;
+      }
+      e_name = d_name;
+      break;
+    }
+    if (r == 0) {
+      dout(10) << ": done for directory=" << entry->epath << dendl;
+      cache_size -= (int)entry->cache_map.size();
+      m_sync_stack.pop();
+      continue;
+    }
+    std::shared_ptr<PeerReplayer::SyncEntry> d_entry =
+        std::make_shared<PeerReplayer::SyncEntry>(
+            std::move(entry_path(entry->epath, e_name)), stx);
+    d_entry->stat_known = true;
+    d_entry->rollout(entry->fh, e_name);
+    ceph_assert(c_inode_raw != nullptr);
+    d_entry->fh.ll_info.c_inode =
+        create_inode_shared_ptr(replayer->m_local_mount, c_inode_raw);
+    if (!entry->create_fresh() && !entry->purge_remote()) {
+      auto it = entry->cache_map.find(e_name);
+      if (it != entry->cache_map.end()) {
+        d_entry->fh.ll_info.p_inode = std::move(it->second.p_inode);
+        d_entry->pstx = it->second.pstx;
+        d_entry->pstat_known = true;
+        d_entry->prev_d_type =
+            (S_ISDIR(d_entry->pstx.stx_mode) ? DT_DIR : DT_REG);
+        entry->cache_map.erase(it);
+        cache_size--;
+        sync_stat->current_stat.inc_cache_hit();
+      }
+    } else {
+      d_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
+    }
+    SyncMechanism *syncm =
+        new DirBruteDiffSync(replayer->m_local_mount, std::move(d_entry),
+                             registry, sync_stat, fh, replayer);
+    if (try_spawning(syncm)) {
+      continue;
+    }
+    break;
+  }
+  return 0;
 }
 
 int DirBruteDiffSync::go_next() {
@@ -2089,7 +3331,7 @@ int DirBruteDiffSync::go_next() {
                              CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                                  CEPH_STATX_SIZE | CEPH_STATX_ATIME |
                                  CEPH_STATX_MTIME,
-                             AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
+                             replayer->sync_flags, NULL);
       if (r < 0) {
         derr << ": failed to local read directory=" << entry->epath << dendl;
         if (replayer->skip_error) {
@@ -2157,6 +3399,125 @@ int DirBruteDiffSync::go_next() {
     break;
   }
   return r;
+}
+
+int DirBruteDiffSync::ll_sync_current_entry() {
+  dout(0) << ": --->" << cur_entry->epath << ", "
+          << ((fh.p_mnt == replayer->m_remote_mount) ? "remote" : "local")
+          << dendl;
+  int r = 0;
+  bool failed_prev =
+      (sync_stat->synced_snap_count == 0 || sync_stat->nr_failures > 0);
+
+  r = ll_populate_cur_stat_and_cur_inode();
+  if (r < 0) {
+    derr << ": failed to populate low level stat and inode of cur snapshot's "
+            "cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                     replayer->m_cct)
+         << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  r = ll_populate_prev_stat_and_prev_inode();
+  if (r < 0) {
+    derr << ": failed to populate low level stat and inode of diff base's cur "
+            "entry="
+         << (fh.p_mnt == replayer->m_local_mount
+                 ? abs_path(registry->dir_root, cur_entry->epath,
+                            (*fh.m_prev).first, replayer->m_cct)
+                 : abs_path(registry->dir_root, cur_entry->epath))
+         << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  bool need_data_sync =
+      !S_ISDIR(cur_entry->stx.stx_mode) &&
+      (cur_entry->create_fresh() || cur_entry->purge_remote() ||
+       (cur_entry->stx.stx_mtime != cur_entry->pstx.stx_mtime) ||
+       (cur_entry->stx.stx_size != cur_entry->pstx.stx_size));
+
+  if (failed_prev && fh.p_mnt == replayer->m_local_mount &&
+      (cur_entry->create_fresh() || cur_entry->purge_remote() ||
+       need_data_sync)) {
+    cur_entry->fh.ll_info.p_parent_inode = cur_entry->fh.ll_info.r_parent_inode;
+    cur_entry->fh.ll_info.p_inode = cur_entry->fh.ll_info.r_inode;
+    cur_entry->fh.ll_info.p_path = cur_entry->fh.ll_info.r_path;
+    cur_entry->change_mask = 0;     // we need to re-calculate for remote
+    cur_entry->pstat_known = false; // we need to re-calculate for remote
+    cur_entry->prev_d_type = -1;    // we need to re-calculate for remote
+    SyncMechanism *syncm = new DirBruteDiffSync(
+        replayer->m_local_mount, std::move(cur_entry), registry, sync_stat,
+        registry->remotediff_fh, replayer);
+    registry->sync_pool->sync_direct(syncm);
+    cur_entry = nullptr;
+    return 0;
+  }
+
+  if (cur_entry->purge_remote()) {
+    SyncMechanism *syncm = new LL_DeleteMechanism(
+        replayer->m_local_mount, cur_entry, registry, sync_stat, fh, replayer);
+    registry->sync_pool->sync_direct(syncm);
+    cur_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
+  }
+
+  if (cur_entry->create_fresh()) {
+    if (S_ISDIR(cur_entry->stx.stx_mode)) {
+      r = ll_remote_mkdir();
+      if (r < 0) {
+        derr << ": failed to do low level mkdir of remote cur entry"
+             << abs_path(registry->dir_root, cur_entry->epath) << ": "
+             << cpp_strerror(r) << dendl;
+        return r;
+      }
+    }
+  }
+
+  if (S_ISDIR(cur_entry->stx.stx_mode)) {
+    r = ll_update_remote_stat();
+    if (r < 0) {
+      derr << ": failed to populate low level stat of remote cur entry"
+              "entry= "
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+  } else {
+    r = ll_remote_file_op();
+    if (r < 0) {
+      derr << ": failed to do low level remote file operation of remote cur "
+              "entry="
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+    cur_entry = nullptr;
+    return 0;
+  }
+  ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+  r = replayer->ll_open_dirp(replayer->m_local_mount,
+                             cur_entry->fh.ll_info.c_inode, cur_entry->udirp,
+                             replayer->m_local_perms);
+  if (r < 0) {
+    derr << ": failed to do low level opendir of cur snapshot's cur entry="
+         << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                     replayer->m_cct)
+         << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  if (!cur_entry->create_fresh() && !cur_entry->purge_remote()) {
+    r = ll_propagate_deleted_entries(cache_size);
+    if (r < 0) {
+      derr << ": failed to propagate deleted entries in remote cur entry="
+           << abs_path(registry->dir_root, cur_entry->epath) << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+  cur_entry->set_remote_synced();
+  m_sync_stack.emplace(std::move(cur_entry));
+  cur_entry = nullptr;
+  return 0;
 }
 
 int DirBruteDiffSync::sync_current_entry() {
@@ -2256,6 +3617,165 @@ void DirBruteDiffSync::finish_sync() {
   }
 }
 
+int PeerReplayer::get_r_stats(const std::string &dir_path, uint64_t &rfiles,
+                              uint64_t &rbytes) {
+  void *buf_file_count = malloc(20);
+  std::string str_rfiles = "";
+  int x1 = ceph_getxattr(m_local_mount, dir_path.c_str(), "ceph.dir.rfiles",
+                         buf_file_count, 20);
+  if (x1 < 0) {
+    derr << ": failed to read ceph.dir.rfiles xattr for directory=" << dir_path
+         << dendl;
+    return x1;
+  } else {
+    str_rfiles = std::move(std::string((char *)buf_file_count, x1));
+    dout(0) << ": xattr ceph.dir.rfiles=" << rfiles
+            << " for directory=" << dir_path << dendl;
+  }
+
+  void *buf_file_bytes = malloc(20);
+  std::string str_rbytes = "";
+  int x2 = ceph_getxattr(m_local_mount, dir_path.c_str(), "ceph.dir.rbytes",
+                         buf_file_bytes, 20);
+  if (x2 < 0) {
+    derr << ": failed to read ceph.dir.rfiles xattr for directory=" << dir_path
+         << dendl;
+    return x2;
+  } else {
+    str_rbytes = std::move(std::string((char *)buf_file_bytes, x2));
+    dout(0) << ": xattr ceph.dir.rbytes=" << rbytes
+            << " for directory=" << dir_path << dendl;
+  }
+  rfiles = std::stoull(str_rfiles);
+  rbytes = std::stoull(str_rbytes);
+  return 0;
+}
+
+int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
+                                    const Snapshot &current,
+                                    boost::optional<Snapshot> prev) {
+  dout(0)
+      << "cephfs_mirror_file_sync_thread="
+      << g_ceph_context->_conf.get_val<uint64_t>(
+             "cephfs_mirror_file_sync_thread")
+      << ", cephfs_mirror_dir_scanning_thread=" << dir_scanning_thread
+      << ", cephfs_mirror_remote_diff_base_upon_start="
+      << remote_diff_base_upon_start
+      << ", cephfs_mirror_sync_latest_snapshot=" << sync_latest_snapshot
+      << ", cephfs_mirror_thread_pool_queue_size=" << thread_pool_queue_size
+      << ", cephfs_mirror_max_element_in_cache_per_thread="
+      << max_element_in_cache_per_thread
+      << ", cephfs_mirror_start_syncing=" << start_syncing
+      << ", cephfs_mirror_max_concurrent_directory_syncs="
+      << max_concurrent_directory_syncs
+      << ", cephfs_mirror_use_snapdiff_api=" << use_snapdiff_api
+      << ", mds_session_blocklist_on_timeout="
+      << g_ceph_context->_conf.get_val<bool>("mds_session_blocklist_on_timeout")
+      << ", mds_session_blocklist_on_evict="
+      << g_ceph_context->_conf.get_val<bool>("mds_session_blocklist_on_evict")
+      << ", client_reconnect_stale="
+      << g_ceph_context->_conf.get_val<bool>("client_reconnect_stale")
+      << ", client_tick_interval="
+      << g_ceph_context->_conf.get_val<std::chrono::seconds>(
+             "client_tick_interval")
+      << ", client_cache_size=" << g_ceph_context->_conf->client_cache_size
+      << ", cephfs_mirror_max_consecutive_failures_before_remote_sync= "
+      << max_consecutive_failures_before_remote_sync
+      << ", cephfs_mirror_skip_error=" << skip_error
+      << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
+      << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
+      << dendl;
+
+  dout(0) << ": sync start-->" << dir_root << ",cur_snap= " << current.first
+          << ", diff_base=" << (prev ? (*prev).first : "remote") << dendl;
+  dout(20) << ": dir_root=" << dir_root << ", current=" << current << dendl;
+  std::unique_lock<ceph::mutex> lock(m_lock);
+  DirRegistry *registry = m_registered.at(dir_root);
+  auto sync_stat = m_snap_sync_stats.at(dir_root);
+  registry->dir_root = dir_root, registry->failed = registry->canceled = false;
+  registry->failed_reason = 0;
+  lock.unlock();
+
+  int r = ll_pre_sync_check_and_open_registry_inodes(dir_root, current, prev,
+                                                     registry);
+  if (r < 0) {
+    derr << ": cannot proceed with pre-sync error for directory=" << dir_root
+         << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  if (registry->snapdiff_fh.ll_info.p_parent_inode == nullptr) {
+    r = set_snap_id_attr(dir_root, "ceph.mirror.diff_base", 0);
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  std::string cur_snap_path = snapshot_path(m_cct, dir_root, current.first);
+  uint64_t rfiles = 0, rbytes = 0;
+  get_r_stats(cur_snap_path, rfiles, rbytes);
+  lock.lock();
+  registry->sync_start(file_mirror_pool.sync_start(dir_root, true));
+  sync_stat->current_stat.rfiles = rfiles;
+  sync_stat->current_stat.rbytes = rbytes;
+  sync_stat->current_stat.start_timer();
+  registry->sync_pool =
+      std::make_unique<DirSyncPool>(dir_scanning_thread, dir_root, m_peer);
+  registry->sync_pool->set_low_level(true);
+  registry->sync_pool->activate();
+  lock.unlock();
+
+  struct ceph_statx stx;
+  SyncMechanism *syncm = nullptr;
+  std::shared_ptr<SyncEntry> cur_entry =
+      std::make_shared<SyncEntry>("");
+  cur_entry->fh = (registry->snapdiff_fh.ll_info.p_parent_inode == nullptr)
+                           ? registry->remotediff_fh
+                           : registry->snapdiff_fh;
+
+  std::shared_ptr <SyncEntry> root_entry = cur_entry;
+
+  if (registry->snapdiff_fh.ll_info.p_parent_inode != nullptr) {
+    if (use_snapdiff_api) {
+      sync_stat->current_stat.set_diff_base("ll_local_snapdiff_diff_base_" +
+                                            (*prev).first);
+      dout(0) << ": started syncing of dir_root=" << dir_root
+              << ", using snapdiff api" << dendl;
+      syncm = new DirSnapDiffSync(m_local_mount, std::move(cur_entry), registry,
+                                  sync_stat, registry->snapdiff_fh, this);
+    } else {
+      sync_stat->current_stat.set_diff_base("ll_local_legacy_diff_base_" +
+                                            (*prev).first);
+      dout(0) << ": started syncing of dir_root=" << dir_root
+              << ", using legacy calculation" << dendl;
+      syncm =
+          new DirBruteDiffSync(m_local_mount, std::move(cur_entry), registry,
+                               sync_stat, registry->snapdiff_fh, this);
+    }
+  } else {
+    dout(0) << ": started syncing of dir_root=" << dir_root
+            << ", using remote as diff base" << dendl;
+    sync_stat->current_stat.set_diff_base("ll_remote");
+    syncm = new DirBruteDiffSync(m_local_mount, std::move(cur_entry), registry,
+                                 sync_stat, registry->remotediff_fh, this);
+  }
+  registry->sync_pool->sync_anyway(syncm);
+  registry->wait_for_sync_finish();
+
+  should_backoff(registry, &r);
+  if (registry->failed) {
+    r = registry->failed_reason;
+  }
+
+  lock.lock();
+  file_mirror_pool.sync_finish(registry->get_file_sync_queue_idx(), dir_root);
+  registry->file_sync_queue_idx = -2;
+  registry->sync_pool->deactivate();
+  registry->sync_pool = nullptr;
+  lock.unlock();
+  dout(0) << ": sync done-->" << dir_root << ", " << current.first << dendl;
+  return r;
+}
+
 int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &current,
                                  boost::optional<Snapshot> prev) {
   dout(0)
@@ -2285,7 +3805,10 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       << ", client_cache_size=" << g_ceph_context->_conf->client_cache_size
       << ", cephfs_mirror_max_consecutive_failures_before_remote_sync= "
       << max_consecutive_failures_before_remote_sync
-      << ", cephfs_mirror_skipp_error=" << skip_error << dendl;
+      << ", cephfs_mirror_skip_error=" << skip_error
+      << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
+      << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
+      << dendl;
 
   dout(0) << ": sync start-->" << dir_root << ",cur_snap= " << current.first
           << ", diff_base=" << (prev ? (*prev).first : "remote") << dendl;
@@ -2332,7 +3855,7 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
   r = ceph_fstatx(m_local_mount, fh->c_fd, &stx,
                   CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                       CEPH_STATX_SIZE | CEPH_STATX_MTIME,
-                  AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                  sync_flags);
   if (r < 0) {
     derr << ": failed to stat snap=" << current.first << ": " << cpp_strerror(r)
          << dendl;
@@ -2385,12 +3908,15 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
 
   if (registry->snapdiff_fh.p_fd >= 0) {
     // dout(0) << ": snapdiff-->" << dendl;
-    sync_stat->current_stat.set_diff_base("local_" + (*prev).first);
     std::shared_ptr<SyncEntry> cur_entry;
     if (use_snapdiff_api) {
+      sync_stat->current_stat.set_diff_base("local_snapdiff_diff_base_" +
+                                            (*prev).first);
       cur_entry =
           std::make_shared<SyncEntry>(".", ceph_snapdiff_info(), stx, 0);
     } else {
+      sync_stat->current_stat.set_diff_base("local_legacy_diff_base_" +
+                                            (*prev).first);
       cur_entry = std::make_shared<SyncEntry>(".", nullptr, stx, 0, true);
     }
     cur_entry->set_stat_known();
@@ -2439,7 +3965,6 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
   registry->file_sync_queue_idx = -2;
   registry->sync_pool->deactivate();
   registry->sync_pool = nullptr;
-  sync_stat->reset_stats(r);
   lock.unlock();
 
   dout(20) << " cur:" << fh->c_fd
@@ -2473,16 +3998,12 @@ int PeerReplayer::synchronize(const std::string &dir_root,
   lock.unlock();
 
   int sync_r = 0, r = 0;
-
-  if (sync_r < 0) {
-    sync_r = do_synchronize(dir_root, current, boost::none);
-  } else {
-    sync_r = do_synchronize(dir_root, current, prev);
-  }
+  sync_r = use_low_level_api ? ll_do_synchronize(dir_root, current, prev)
+                             : do_synchronize(dir_root, current, prev);
 
   // snap sync failed -- bail out!
   if (sync_r < 0) {
-    if (!skip_error || (registry->failed && should_backoff(registry, &r))) {
+    if (!skip_error || (should_backoff(registry, &r))) {
       return sync_r;
     }
   }
@@ -2497,6 +4018,7 @@ int PeerReplayer::synchronize(const std::string &dir_root,
   if (r < 0) {
     derr << ": failed to snap remote directory dir_root=" << dir_root << ": "
          << cpp_strerror(r) << dendl;
+    return r;
   }
   *took_snapshot = true;
   r = set_snap_id_attr(dir_root, "ceph.mirror.diff_base", current.second);
@@ -2509,7 +4031,7 @@ int PeerReplayer::synchronize(const std::string &dir_root,
     return r;
   }
 
-  return sync_r;
+  return (sync_r < 0 ? sync_r : r);
 }
 
 int64_t PeerReplayer::get_snap_id_attr(const std::string &dir_root,
@@ -2817,6 +4339,7 @@ int PeerReplayer::_do_sync_snaps(const std::string &dir_root, Snapshot cur_snap,
   if (r < 0) {
     return r;
   }
+  r = 0;
 
   bool took_snapshot = false;
   int sync_r = synchronize(dir_root, cur_snap, prev, &took_snapshot);
@@ -2831,6 +4354,11 @@ int PeerReplayer::_do_sync_snaps(const std::string &dir_root, Snapshot cur_snap,
            << ", snapshot=" << cur_snap.first
            << ", but still proceed taking snapshot in remote" << dendl;
     }
+  }
+  if (took_snapshot) {
+    std::unique_lock<ceph::mutex> lock(m_lock);
+    auto sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat->reset_stats(0);
   }
   if (m_perf_counters) {
     m_perf_counters->inc(l_cephfs_mirror_peer_replayer_snaps_synced);
@@ -2914,7 +4442,10 @@ void PeerReplayer::run_scan() {
                                m_directories.size() > m_registered.size() &&
                                !m_directories.empty());
     });
-
+    if (is_stopping()) {
+      dout(5) << ": exiting" << dendl;
+      break;
+    }
     cleanup_idle_threads(locker);
 
     auto scan_interval = g_ceph_context->_conf.get_val<uint64_t>(
@@ -2931,10 +4462,6 @@ void PeerReplayer::run_scan() {
                       [this] { return is_stopping(); });
     }
 
-    if (is_stopping()) {
-      dout(5) << ": exiting" << dendl;
-      break;
-    }
     if (!(start_syncing && nr_replayers > 0 &&
           m_directories.size() > m_registered.size() &&
           !m_directories.empty())) {
@@ -2954,12 +4481,12 @@ void PeerReplayer::run_scan() {
     if (idx >= m_directories.size() || m_directories[idx] != next_dir) {
       idx = std::find(m_directories.begin(), m_directories.end(), next_dir) -
             m_directories.begin();
-      if (idx >= m_directories.size()) {
+      if (idx >= (int)m_directories.size()) {
         idx = (int)m_directories.size() - 1;
       }
     }
 
-    for (int i = 0; i < m_directories.size() && nr_replayers > 0 &&
+    for (int i = 0; i < (int)m_directories.size() && nr_replayers > 0 &&
                     m_directories.size() > m_registered.size();
          ++i, idx = (idx + 1) % m_directories.size()) {
       next_dir = m_directories[idx];

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -288,6 +288,12 @@ PeerReplayer::PeerReplayer(
       (use_at_statx_dont_sync ? AT_STATX_DONT_SYNC : 0) | AT_SYMLINK_NOFOLLOW;
   stat_flush_counter_gap = g_ceph_context->_conf.get_val<uint64_t>(
         "cephfs_mirror_stat_flush_counter_gap");
+  turn_off_assert =
+      g_ceph_context->_conf.get_val<bool>("cephfs_mirror_turn_off_assert");
+  snap_prefix =
+      g_ceph_context->_conf.get_val<std::string>("cephfs_mirror_snap_prefix");
+  sync_from_remote =
+      g_ceph_context->_conf.get_val<bool>("cephfs_mirror_sync_from_remote");
 }
 
 PeerReplayer::~PeerReplayer() {
@@ -434,6 +440,18 @@ void PeerReplayer::handle_conf_change(const ConfigProxy &conf,
     stat_flush_counter_gap = g_ceph_context->_conf.get_val<uint64_t>(
         "cephfs_mirror_stat_flush_counter_gap");
   }
+  if (changed.count("cephfs_mirror_turn_off_assert")) {
+    turn_off_assert =
+        g_ceph_context->_conf.get_val<bool>("cephfs_mirror_turn_off_assert");
+  }
+  if (changed.count("cephfs_mirror_snap_prefix")) {
+    snap_prefix =
+        g_ceph_context->_conf.get_val<std::string>("cephfs_mirror_snap_prefix");
+  }
+  if (changed.count("cephfs_mirror_sync_from_remote")) {
+    sync_from_remote =
+        g_ceph_context->_conf.get_val<bool>("cephfs_mirror_sync_from_remote");
+  }
 
   m_cond.notify_all();
   dout(0)
@@ -471,7 +489,9 @@ void PeerReplayer::handle_conf_change(const ConfigProxy &conf,
       << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
       << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
       << ", cephfs_mirror_stat_flush_counter_gap=" << stat_flush_counter_gap
-      << dendl;
+      << ", cephfs_mirror_turn_off_assert=" << turn_off_assert
+      << ", cephfs_mirror_snap_prefix=" << snap_prefix
+      << ", cephfs_mirror_sync_from_remote=" << sync_from_remote << dendl;
 }
 
 const char **PeerReplayer::get_tracked_conf_keys() const {
@@ -491,6 +511,9 @@ const char **PeerReplayer::get_tracked_conf_keys() const {
                                "cephfs_mirror_use_low_level_api",
                                "cephfs_mirror_use_at_statx_dont_sync",
                                "cephfs_mirror_stat_flush_counter_gap",
+                               "cephfs_mirror_turn_off_assert",
+                               "cephfs_mirror_snap_prefix",
+                               "cephfs_mirror_sync_from_remote",
                                NULL};
   return KEYS;
 }
@@ -974,10 +997,11 @@ int SyncMechanism::ll_remote_mkdir() {
          << cpp_strerror(r) << dendl;
     return r;
   }
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
-  ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
-  ceph_assert(cur_entry->fh.ll_info.r_info.inode == nullptr);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  }
   r = 0;
   InodeRawPtr raw_inode = nullptr;
   struct ceph_statx rstx;
@@ -989,7 +1013,9 @@ int SyncMechanism::ll_remote_mkdir() {
   if (r < 0) {
     return r;
   }
-  ceph_assert(raw_inode != nullptr);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(raw_inode != nullptr);
+  }
   cur_entry->fh.ll_info.r_info.inode =
       create_inode_shared_ptr(replayer->m_remote_mount, raw_inode);
   local_stat->inc_dir_created_count(sync_stat->current_stat,
@@ -1032,8 +1058,10 @@ int FileSyncMechanism::ll_copy_to_remote() {
   }
   file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_OPEN_LOCAL;
   FhRawPtr fh_raw = nullptr;
-  ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
-  ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
+  }
   // dout(0) << ": --->" << cur_entry->epath
   //         << ", in=" << cur_entry->fh.ll_info.c_inode.get() << dendl;
   r = ceph_ll_open(replayer->m_local_mount,
@@ -1046,7 +1074,9 @@ int FileSyncMechanism::ll_copy_to_remote() {
          << ": " << cpp_strerror(r) << dendl;
     return r;
   }
-  ceph_assert(fh_raw != nullptr);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(fh_raw != nullptr);
+  }
   FhUniquePtr l_fh = create_fh_unique_ptr(replayer->m_local_mount, fh_raw);
   file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_OPEN_REMOTE;
 
@@ -1065,9 +1095,11 @@ int FileSyncMechanism::ll_copy_to_remote() {
            << cpp_strerror(r) << dendl;
       return r;
     }
-    ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
-    ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
-    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+      ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+      ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+    }
     InodeRawPtr inode_raw = nullptr;
     r = ceph_ll_create(replayer->m_remote_mount,
                        cur_entry->fh.ll_info.r_info.parent->inode.get(),
@@ -1081,7 +1113,9 @@ int FileSyncMechanism::ll_copy_to_remote() {
            << cpp_strerror(r) << dendl;
       return r;
     }
-    ceph_assert(inode_raw != nullptr);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(inode_raw != nullptr);
+    }
     cur_entry->fh.ll_info.r_info.inode =
         create_inode_shared_ptr(replayer->m_remote_mount, inode_raw);
   } else {
@@ -1095,7 +1129,9 @@ int FileSyncMechanism::ll_copy_to_remote() {
       return r;
     }
   }
-  ceph_assert(fh_raw != nullptr);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(fh_raw != nullptr);
+  }
   FhUniquePtr r_fh = create_fh_unique_ptr(replayer->m_remote_mount, fh_raw);
   void *ptr = malloc(NR_IOVECS * IOVEC_SIZE);
   if (!ptr) {
@@ -1313,9 +1349,11 @@ int SyncMechanism::ll_unlink_cur_file_entry() {
          << cpp_strerror(r) << dendl;
     return r;
   }
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
-  ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  }
   r = ceph_ll_unlink(replayer->m_remote_mount,
                      cur_entry->fh.ll_info.r_info.parent->inode.get(),
                      cur_entry->fh.ll_info.r_info.path.c_str(),
@@ -1343,9 +1381,11 @@ int SyncMechanism::ll_unlink_cur_dir_entry() {
          << cpp_strerror(r) << dendl;
     return r;
   }
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
-  ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  }
   r = ceph_ll_rmdir(replayer->m_remote_mount,
                         cur_entry->fh.ll_info.r_info.parent->inode.get(),
                         cur_entry->fh.ll_info.r_info.path.c_str(),
@@ -1395,7 +1435,9 @@ int SyncMechanism::ll_remote_file_op() {
         return r;
       }
       char *target = (char *)alloca(cstx.stx_size + 1);
-      ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+      if (!replayer->turn_off_assert) {
+        ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+      }
       r = ceph_ll_readlink(replayer->m_local_mount,
                            cur_entry->fh.ll_info.c_info.inode.get(), target,
                            cstx.stx_size, replayer->m_local_perms);
@@ -1407,9 +1449,11 @@ int SyncMechanism::ll_remote_file_op() {
              << ": " << cpp_strerror(r) << dendl;
         return r;
       }
-      ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
-      ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
-      ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+      if (!replayer->turn_off_assert) {
+        ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+        ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+        ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+      }
       struct ceph_statx rstx;
       InodeRawPtr link_raw = nullptr;
       target[cstx.stx_size] = '\0';
@@ -1427,7 +1471,9 @@ int SyncMechanism::ll_remote_file_op() {
       } else if (r == -EEXIST) {
         cur_entry->fh.ll_info.r_info.inode = nullptr; // need to check
       } else {
-        ceph_assert(link_raw != nullptr);
+        if (!replayer->turn_off_assert) {
+          ceph_assert(link_raw != nullptr);
+        }
         cur_entry->fh.ll_info.r_info.inode =
             create_inode_shared_ptr(replayer->m_remote_mount, link_raw);
       }
@@ -1528,8 +1574,10 @@ int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
 
 int SyncMechanism::ll_cleanup_remote_entry() {
   // dout(0) << ": --->" << cur_entry->epath << dendl;
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+  }
   int r = 0;
   if (cur_entry->prev_d_type != DT_DIR) {
     r = ll_unlink_cur_file_entry();
@@ -1545,8 +1593,10 @@ int SyncMechanism::ll_cleanup_remote_entry() {
     } else if (r == -ENOENT) {
       return 0;
     }
-    ceph_assert(cur_entry->fh.ll_info.r_info.inode != nullptr);
-    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(cur_entry->fh.ll_info.r_info.inode != nullptr);
+      ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+    }
     r = replayer->ll_open_dirp(replayer->m_remote_mount,
                                cur_entry->fh.ll_info.r_info.inode,
                                cur_entry->udirp, replayer->m_remote_perms);
@@ -1572,8 +1622,10 @@ int SyncMechanism::ll_cleanup_remote_entry() {
       }
       return 0;
     }
-    ceph_assert(cur_entry->fh.ll_info.r_info.inode != nullptr);
-    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(cur_entry->fh.ll_info.r_info.inode != nullptr);
+      ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+    }
     r = replayer->ll_open_dirp(replayer->m_remote_mount,
                                cur_entry->fh.ll_info.r_info.inode,
                                cur_entry->udirp, replayer->m_remote_perms);
@@ -1614,9 +1666,11 @@ int SyncMechanism::ll_cleanup_remote_entry() {
     std::shared_ptr<PeerReplayer::SyncEntry> d_entry =
         std::make_shared<PeerReplayer::SyncEntry>(
             std::move(entry_path(cur_entry->epath, d_name)));
-    d_entry->rollout(cur_entry->fh, d_name);
+    d_entry->rollout(cur_entry->fh, d_name, replayer);
     d_entry->prev_d_type = (int)de.d_type;
-    ceph_assert(r_inode_raw != nullptr);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(r_inode_raw != nullptr);
+    }
     d_entry->fh.ll_info.r_info.inode =
         create_inode_shared_ptr(replayer->m_remote_mount, r_inode_raw);
     SyncMechanism *syncm =
@@ -1853,10 +1907,12 @@ int PeerReplayer::should_sync_entry(const std::string &epath, const struct ceph_
 
 int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
   // dout(0) << ": --->" << cur_entry->epath << dendl;
-  ceph_assert(cur_entry->fh.ll_info.p_info.inode != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
-  ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
-  ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.p_info.inode != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
+    ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
+  }
   int r = 0;
   DirUniquePtr udirp;
   r = replayer->ll_open_dirp(fh.p_mnt, cur_entry->fh.ll_info.p_info.inode,
@@ -1899,7 +1955,9 @@ int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
     if (d_name == "." || d_name == "..") {
       continue;
     }
-    ceph_assert(p_inode_raw != nullptr);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(p_inode_raw != nullptr);
+    }
     InodeSharedPtr p_inode = create_inode_shared_ptr(fh.p_mnt, p_inode_raw);
     std::string epath = std::move(entry_path(cur_entry->epath, d_name));
     InodeSharedPtr c_inode = nullptr;
@@ -1930,7 +1988,7 @@ int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
     if (purge_remote && !entry_present) {
       std::shared_ptr<PeerReplayer::SyncEntry> d_entry =
           std::make_shared<PeerReplayer::SyncEntry>(std::move(epath));
-      d_entry->rollout(cur_entry->fh, d_name);
+      d_entry->rollout(cur_entry->fh, d_name, replayer);
       d_entry->prev_d_type = (int)de.d_type;
       d_entry->fh.ll_info.p_info.inode = std::move(p_inode);
       SyncMechanism *syncm =
@@ -2075,7 +2133,9 @@ int PeerReplayer::ll_open_inode(MountRef mnt, InodeSharedPtr &parent,
     inode_shared = nullptr;
     return r;
   }
-  ceph_assert(inode != nullptr);
+  if (!turn_off_assert) {
+    ceph_assert(inode != nullptr);
+  }
   inode_shared = create_inode_shared_ptr(mnt, inode);
   return 0;
 }
@@ -2083,8 +2143,10 @@ int PeerReplayer::ll_open_inode(MountRef mnt, InodeSharedPtr &parent,
 int PeerReplayer::ll_reduce_gap(MountRef mnt,
                                 FHandles::LL_Fhandle_Info::InodeInfo &info,
                                 UserPermRef perms) {
-  ceph_assert(info.parent != nullptr);
-  ceph_assert(info.parent->inode != nullptr);
+  if (!turn_off_assert) {
+    ceph_assert(info.parent != nullptr);
+    ceph_assert(info.parent->inode != nullptr);
+  }
   if (!info.gap) {
     return 0;
   }
@@ -2109,7 +2171,9 @@ int PeerReplayer::ll_reduce_gap(MountRef mnt,
       inode = nullptr;
       return r;
     }
-    ceph_assert(inode != nullptr);
+    if (!turn_off_assert) {
+      ceph_assert(inode != nullptr);
+    }
     info.parent = std::make_shared<AncestorsLink>(
         std::move(info.parent), std::move(create_inode_shared_ptr(mnt, inode)));
   }
@@ -2144,7 +2208,9 @@ int PeerReplayer::ll_open_dirp(MountRef mnt, InodeSharedPtr &inode,
     udirp = nullptr;
     return r;
   }
-  ceph_assert(rdirp != nullptr);
+  if (!turn_off_assert) {
+    ceph_assert(rdirp != nullptr);
+  }
   udirp = create_dirp_unique_ptr(mnt, rdirp);
   return 0;
 }
@@ -2550,13 +2616,15 @@ void PeerReplayer::DirSyncPool::update_qlimit(int _qlimit) {
   qlimit = _qlimit;
 }
 
-bool SyncMechanism::ll_populate_remote_inode_with_diff_base() {
+bool SyncMechanism::ll_populate_remote_inode_with_diff_base() { // need to be checked
   if (fh.p_mnt == replayer->m_remote_mount &&
       cur_entry->fh.ll_info.r_info.inode == nullptr &&
       cur_entry->fh.ll_info.p_info.inode != nullptr &&
       !cur_entry->fh.ll_info.p_info.gap && cur_entry->fh.ll_info.r_info.gap) {
-    ceph_assert(cur_entry->fh.ll_info.p_info.parent != nullptr);
-    ceph_assert(cur_entry->fh.ll_info.p_info.parent->inode != nullptr);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(cur_entry->fh.ll_info.p_info.parent != nullptr);
+      ceph_assert(cur_entry->fh.ll_info.p_info.parent->inode != nullptr);
+    }
     cur_entry->fh.ll_info.r_info = cur_entry->fh.ll_info.p_info;
     return true;
   }
@@ -2565,10 +2633,14 @@ bool SyncMechanism::ll_populate_remote_inode_with_diff_base() {
 
 int SyncMechanism::ll_populate_remote_inode() {
   int r = 0;
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
+  }
   if (cur_entry->fh.ll_info.r_info.inode != nullptr) {
-    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+    }
     return 0;
   }
   if (!ll_populate_remote_inode_with_diff_base()) {
@@ -2629,9 +2701,10 @@ int SyncMechanism::ll_update_remote_stat() {
          << cpp_strerror(r) << dendl;
     return r;
   }
-
-  ceph_assert(cur_entry->fh.ll_info.r_info.inode != nullptr);
-  ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.r_info.inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
+  }
   r = ceph_ll_setattr(replayer->m_remote_mount,
                       cur_entry->fh.ll_info.r_info.inode.get(), &cstx, mask,
                       replayer->m_remote_perms);
@@ -2658,9 +2731,11 @@ int SyncMechanism::ll_populate_cur_stat_and_cur_inode() {
   int r = 0;
   int mask = CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
              CEPH_STATX_SIZE | CEPH_STATX_MTIME;
-  ceph_assert(cur_entry->fh.ll_info.c_info.parent != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.c_info.parent->inode != nullptr);
-  ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.c_info.parent != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.c_info.parent->inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
+  }
   if (cur_entry->fh.ll_info.c_info.inode == nullptr) {
     r = replayer->ll_open_inode(
         replayer->m_local_mount, cur_entry->fh.ll_info.c_info, cur_entry->stx,
@@ -2722,13 +2797,17 @@ int SyncMechanism::ll_populate_prev_stat_and_prev_inode() {
   if (create_fresh || (purge_remote && cur_entry->prev_d_type != -1)) {
     return 0;
   }
-  ceph_assert(cur_entry->fh.ll_info.p_info.parent != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.p_info.parent->inode != nullptr);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.p_info.parent != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.p_info.parent->inode != nullptr);
+  }
   if (cur_entry->fh.ll_info.p_info.inode == nullptr) {
     r = replayer->ll_open_inode(
         fh.p_mnt, cur_entry->fh.ll_info.p_info, cur_entry->pstx,
         (cur_entry->pstat_known ? 0 : mask), fh.ll_info.p_perms);
-    ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
+    }
     if (r < 0 && r != -ENOENT) {
       derr << ": failed to do low level openning of diff base's cur entry= "
            << (fh.p_mnt == replayer->m_local_mount
@@ -2739,7 +2818,9 @@ int SyncMechanism::ll_populate_prev_stat_and_prev_inode() {
       return r;
     }
   } else if (!cur_entry->pstat_known) {
-    ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
+    }
     r = ceph_ll_getattr(fh.p_mnt, cur_entry->fh.ll_info.p_info.inode.get(),
                         &cur_entry->pstx, mask, replayer->sync_flags,
                         fh.ll_info.p_perms);
@@ -2978,15 +3059,20 @@ bool DirSyncMechanism::try_spawning(SyncMechanism *syncm) {
 }
 
 void PeerReplayer::SyncEntry::rollout(FHandles &parent_fh,
-                                      const std::string &ename) {
-  ceph_assert(parent_fh.ll_info.c_info.parent != nullptr);
-  ceph_assert(parent_fh.ll_info.c_info.parent->inode != nullptr);
-  ceph_assert(parent_fh.ll_info.p_info.parent != nullptr);
-  ceph_assert(parent_fh.ll_info.p_info.parent->inode != nullptr);
-  ceph_assert(parent_fh.ll_info.r_info.parent != nullptr);
-  ceph_assert(parent_fh.ll_info.r_info.parent->inode != nullptr);
+                                      const std::string &ename,
+                                      PeerReplayer *replayer) {
+  if (!replayer->turn_off_assert) {
+    ceph_assert(parent_fh.ll_info.c_info.parent != nullptr);
+    ceph_assert(parent_fh.ll_info.c_info.parent->inode != nullptr);
+    ceph_assert(parent_fh.ll_info.p_info.parent != nullptr);
+    ceph_assert(parent_fh.ll_info.p_info.parent->inode != nullptr);
+    ceph_assert(parent_fh.ll_info.r_info.parent != nullptr);
+    ceph_assert(parent_fh.ll_info.r_info.parent->inode != nullptr);
+  }
   if (parent_fh.ll_info.c_info.inode != nullptr) {
-    ceph_assert(!parent_fh.ll_info.c_info.gap);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(!parent_fh.ll_info.c_info.gap);
+    }
     fh.ll_info.c_info.parent = std::make_shared<AncestorsLink>(
         parent_fh.ll_info.c_info.parent, parent_fh.ll_info.c_info.inode);
     fh.ll_info.c_info.gap = false;
@@ -2998,7 +3084,9 @@ void PeerReplayer::SyncEntry::rollout(FHandles &parent_fh,
         std::move(entry_path(parent_fh.ll_info.c_info.path, ename));
   }
   if (parent_fh.ll_info.p_info.inode != nullptr) {
-    ceph_assert(!parent_fh.ll_info.p_info.gap);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(!parent_fh.ll_info.p_info.gap);
+    }
     fh.ll_info.p_info.parent = std::make_shared<AncestorsLink>(
         parent_fh.ll_info.p_info.parent, parent_fh.ll_info.p_info.inode);
     fh.ll_info.p_info.gap = false;
@@ -3010,7 +3098,9 @@ void PeerReplayer::SyncEntry::rollout(FHandles &parent_fh,
         std::move(entry_path(parent_fh.ll_info.p_info.path, ename));
   }
   if (parent_fh.ll_info.r_info.inode != nullptr) {
-    ceph_assert(!parent_fh.ll_info.r_info.gap);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(!parent_fh.ll_info.r_info.gap);
+    }
     fh.ll_info.r_info.parent = std::make_shared<AncestorsLink>(
         parent_fh.ll_info.r_info.parent, parent_fh.ll_info.r_info.inode);
     fh.ll_info.r_info.gap = false;
@@ -3075,7 +3165,7 @@ int DirSnapDiffSync::ll_go_next() {
         std::shared_ptr<PeerReplayer::SyncEntry> deleted_entry =
             std::make_shared<PeerReplayer::SyncEntry>(
                 std::move(entry_path(entry->epath, deleted_sibling_d_name)));
-        deleted_entry->rollout(entry->fh, deleted_sibling_d_name);
+        deleted_entry->rollout(entry->fh, deleted_sibling_d_name, replayer);
         deleted_entry->prev_d_type =
             (int)deleted_entry->deleted_sibling.dir_entry.d_type;
         SyncMechanism *syncm = new LL_DeleteMechanism(
@@ -3110,7 +3200,7 @@ int DirSnapDiffSync::ll_go_next() {
     }
     std::shared_ptr<PeerReplayer::SyncEntry> d_entry =
         std::make_shared<PeerReplayer::SyncEntry>(std::move(epath));
-    d_entry->rollout(entry->fh, e_name);
+    d_entry->rollout(entry->fh, e_name, replayer);
     if (entry->deleted_sibling_exist &&
         sd_entry.snapid == fh.m_current.second &&
         e_name == entry->deleted_sibling.dir_entry.d_name) {
@@ -3293,8 +3383,12 @@ int DirSnapDiffSync::ll_sync_current_entry() {
     cur_entry = nullptr;
     return 0;
   }
-  ceph_assert(cur_entry->fh.ll_info.p_info.inode != nullptr);
-  ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.p_info.inode != nullptr);
+    ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+    ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
+    ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
+  }
   r = ceph_ll_open_snapdiff(replayer->m_local_mount,
                             cur_entry->fh.ll_info.p_info.inode.get(),
                             cur_entry->fh.ll_info.c_info.inode.get(),
@@ -3486,8 +3580,10 @@ int DirBruteDiffSync::ll_go_next() {
         std::make_shared<PeerReplayer::SyncEntry>(
             std::move(entry_path(entry->epath, e_name)), stx);
     d_entry->stat_known = true;
-    d_entry->rollout(entry->fh, e_name);
-    ceph_assert(c_inode_raw != nullptr);
+    d_entry->rollout(entry->fh, e_name, replayer);
+    if (!replayer->turn_off_assert) {
+      ceph_assert(c_inode_raw != nullptr);
+    }
     d_entry->fh.ll_info.c_info.inode =
         create_inode_shared_ptr(replayer->m_local_mount, c_inode_raw);
     if (!entry->create_fresh() && !entry->purge_remote()) {
@@ -3699,7 +3795,9 @@ int DirBruteDiffSync::ll_sync_current_entry() {
     cur_entry = nullptr;
     return 0;
   }
-  ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+  if (!replayer->turn_off_assert) {
+    ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
+  }
   r = replayer->ll_open_dirp(replayer->m_local_mount,
                              cur_entry->fh.ll_info.c_info.inode,
                              cur_entry->udirp, replayer->m_local_perms);
@@ -3892,7 +3990,9 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
       << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
       << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
       << ", cephfs_mirror_stat_flush_counter_gap=" << stat_flush_counter_gap
-      << dendl;
+      << ", cephfs_mirror_turn_off_assert=" << turn_off_assert
+      << ", cephfs_mirror_snap_prefix=" << snap_prefix
+      << ", cephfs_mirror_sync_from_remote=" << sync_from_remote << dendl;
   // ceph_assert(sync_flags == AT_SYMLINK_NOFOLLOW);
   // sync_flags = AT_SYMLINK_NOFOLLOW;
 
@@ -4021,7 +4121,9 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
       << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
       << ", cephfs_mirror_stat_flush_counter_gap=" << stat_flush_counter_gap
-      << dendl;
+      << ", cephfs_mirror_turn_off_assert=" << turn_off_assert
+      << ", cephfs_mirror_snap_prefix=" << snap_prefix
+      << ", cephfs_mirror_sync_from_remote=" << sync_from_remote << dendl;
 
   dout(0) << ": sync start-->" << dir_root << ",cur_snap= " << current.first
           << ", diff_base=" << (prev ? (*prev).first : "remote") << dendl;
@@ -4337,7 +4439,8 @@ int PeerReplayer::get_candidate_snap(
   auto& dir_sync_stat = m_snap_sync_stats.at(dir_root);
   if ((remote_diff_base_upon_start && dir_sync_stat->synced_snap_count == 0) ||
       dir_sync_stat->nr_failures >=
-          max_consecutive_failures_before_remote_sync) {
+          max_consecutive_failures_before_remote_sync ||
+      sync_from_remote) {
     remote_diff_base = true;
   }
   locker.unlock();
@@ -4398,31 +4501,39 @@ int PeerReplayer::get_candidate_snap(
   }
 
   if (sync_latest_snapshot) {
-    if (local_snap_map.empty()) {
-      dout(20) << ": nothing to synchronize" << dendl;
-      last_snap = cur_snap = {"", 0};
-      return 0;
-    }
     if (it == local_snap_map.end()) {
       it = prev(local_snap_map.end());
+      for (;; it--) {
+        if (it->second.starts_with(snap_prefix)) {
+          break;
+        }
+        if (it == local_snap_map.begin()) {
+          it = local_snap_map.end();
+          break;
+        }
+      }
     }
-    cur_snap = {it->second, it->first};
   } else {
     if (it == local_snap_map.end()) {
       it = remote_snap_map.empty()
                ? local_snap_map.begin()
                : local_snap_map.upper_bound(remote_snap_map.rbegin()->first);
-    }
-
-    if (it != local_snap_map.end()) {
-      cur_snap = {it->second, it->first};
-    } else {
-      last_snap = cur_snap = {"", 0};
+      for (; it != local_snap_map.end(); ++it) {
+        if (it->second.starts_with(snap_prefix)) {
+          break;
+        }
+      }
     }
   }
 
+  if (it != local_snap_map.end()) {
+    cur_snap = {it->second, it->first};
+  } else {
+    last_snap = cur_snap = {"", 0};
+  }
+
   if (!remote_snap_map.empty() &&
-      cur_snap.second == remote_snap_map.rbegin()->first) {
+      cur_snap.second <= remote_snap_map.rbegin()->first) {
     last_snap = cur_snap = {"", 0};
   }
 

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -294,6 +294,12 @@ PeerReplayer::PeerReplayer(
       g_ceph_context->_conf.get_val<std::string>("cephfs_mirror_snap_prefix");
   sync_from_remote =
       g_ceph_context->_conf.get_val<bool>("cephfs_mirror_sync_from_remote");
+  enable_local_batching = g_ceph_context->_conf.get_val<bool>(
+      "cephfs_mirror_enable_local_batching");
+  local_batch_size =
+      g_ceph_context->_conf.get_val<uint64_t>("cephfs_mirror_local_batch_size");
+  reset_inode_before_submission = g_ceph_context->_conf.get_val<bool>(
+      "cephfs_mirror_reset_inode_before_submission");
 }
 
 PeerReplayer::~PeerReplayer() {
@@ -452,6 +458,18 @@ void PeerReplayer::handle_conf_change(const ConfigProxy &conf,
     sync_from_remote =
         g_ceph_context->_conf.get_val<bool>("cephfs_mirror_sync_from_remote");
   }
+  if (changed.count("cephfs_mirror_enable_local_batching")) {
+    enable_local_batching = g_ceph_context->_conf.get_val<bool>(
+        "cephfs_mirror_enable_local_batching");
+  }
+  if (changed.count("cephfs_mirror_local_batch_size")) {
+    local_batch_size = g_ceph_context->_conf.get_val<uint64_t>(
+        "cephfs_mirror_local_batch_size");
+  }
+  if (changed.count("cephfs_mirror_reset_inode_before_submission")) {
+    reset_inode_before_submission = g_ceph_context->_conf.get_val<bool>(
+        "cephfs_mirror_reset_inode_before_submission");
+  }
 
   m_cond.notify_all();
   dout(0)
@@ -491,30 +509,38 @@ void PeerReplayer::handle_conf_change(const ConfigProxy &conf,
       << ", cephfs_mirror_stat_flush_counter_gap=" << stat_flush_counter_gap
       << ", cephfs_mirror_turn_off_assert=" << turn_off_assert
       << ", cephfs_mirror_snap_prefix=" << snap_prefix
-      << ", cephfs_mirror_sync_from_remote=" << sync_from_remote << dendl;
+      << ", cephfs_mirror_sync_from_remote=" << sync_from_remote
+      << ", cephfs_mirror_enable_local_batching=" << enable_local_batching
+      << ", cephfs_mirror_local_batch_size=" << local_batch_size
+      << ", cephfs_mirror_reset_inode_before_submission=" << reset_inode_before_submission
+      << dendl;
 }
 
 const char **PeerReplayer::get_tracked_conf_keys() const {
-  static const char *KEYS[] = {"cephfs_mirror_dir_scanning_thread",
-                               "cephfs_mirror_thread_pool_queue_size",
-                               "cephfs_mirror_max_element_in_cache_per_thread",
-                               "cephfs_mirror_sync_latest_snapshot",
-                               "cephfs_mirror_remote_diff_base_upon_start",
-                               "cephfs_mirror_start_syncing",
-                               "cephfs_mirror_max_concurrent_directory_syncs",
-                               "cephfs_mirror_use_snapdiff_api",
-                               "cephfs_mirror_lock_directory_before_sync",
-                               "cephfs_mirror_remote_timeout",
-                               "cephfs_mirror_local_timeout",
-                               "cephfs_mirror_max_consecutive_failures_before_remote_sync",
-                               "cephfs_mirror_skip_error",
-                               "cephfs_mirror_use_low_level_api",
-                               "cephfs_mirror_use_at_statx_dont_sync",
-                               "cephfs_mirror_stat_flush_counter_gap",
-                               "cephfs_mirror_turn_off_assert",
-                               "cephfs_mirror_snap_prefix",
-                               "cephfs_mirror_sync_from_remote",
-                               NULL};
+  static const char *KEYS[] = {
+      "cephfs_mirror_dir_scanning_thread",
+      "cephfs_mirror_thread_pool_queue_size",
+      "cephfs_mirror_max_element_in_cache_per_thread",
+      "cephfs_mirror_sync_latest_snapshot",
+      "cephfs_mirror_remote_diff_base_upon_start",
+      "cephfs_mirror_start_syncing",
+      "cephfs_mirror_max_concurrent_directory_syncs",
+      "cephfs_mirror_use_snapdiff_api",
+      "cephfs_mirror_lock_directory_before_sync",
+      "cephfs_mirror_remote_timeout",
+      "cephfs_mirror_local_timeout",
+      "cephfs_mirror_max_consecutive_failures_before_remote_sync",
+      "cephfs_mirror_skip_error",
+      "cephfs_mirror_use_low_level_api",
+      "cephfs_mirror_use_at_statx_dont_sync",
+      "cephfs_mirror_stat_flush_counter_gap",
+      "cephfs_mirror_turn_off_assert",
+      "cephfs_mirror_snap_prefix",
+      "cephfs_mirror_sync_from_remote",
+      "cephfs_mirror_enable_local_batching",
+      "cephfs_mirror_local_batch_size",
+      "cephfs_mirror_reset_inode_before_submission",
+      NULL};
   return KEYS;
 }
 
@@ -671,7 +697,7 @@ void PeerReplayer::remove_directory(string_view dir_root) {
     it1->second->canceled.store(true);
     int sync_idx = it1->second->get_file_sync_queue_idx();
     if (sync_idx >= 0) {
-      file_mirror_pool.drain_queue(sync_idx);
+      file_mirror_pool.deactivate_queue(sync_idx);
     }
     if (it1->second->sync_pool) {
       it1->second->sync_pool->drain_queue();
@@ -987,6 +1013,24 @@ int PeerReplayer::_remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
   return 0;
 }
 
+void SyncMechanism::reset_inode() {
+  cur_entry->fh.ll_info.c_info.parent = fh.ll_info.c_info.parent;
+  cur_entry->fh.ll_info.c_info.path = cur_entry->epath;
+  cur_entry->fh.ll_info.c_info.inode = nullptr;
+  cur_entry->fh.ll_info.c_info.gap = true;
+
+  cur_entry->fh.ll_info.p_info.parent = fh.ll_info.p_info.parent;
+  cur_entry->fh.ll_info.p_info.path = cur_entry->epath;
+  cur_entry->fh.ll_info.p_info.inode = nullptr;
+  cur_entry->fh.ll_info.p_info.gap = true;
+
+  cur_entry->fh.ll_info.r_info.parent = fh.ll_info.r_info.parent;
+  cur_entry->fh.ll_info.r_info.path = cur_entry->epath;
+  cur_entry->fh.ll_info.r_info.inode = nullptr;
+  cur_entry->fh.ll_info.r_info.gap = true;
+  has_reset_inode = true;
+}
+
 int SyncMechanism::ll_remote_mkdir() {
   int r = replayer->ll_reduce_gap(replayer->m_remote_mount,
                                   cur_entry->fh.ll_info.r_info,
@@ -1058,21 +1102,58 @@ int FileSyncMechanism::ll_copy_to_remote() {
   }
   file_worker->state = FileMirrorPool::FileWorker::ThreadState::FILE_OPEN_LOCAL;
   FhRawPtr fh_raw = nullptr;
-  if (!replayer->turn_off_assert) {
+  InodeRawPtr inode_raw = nullptr;
+  struct ceph_statx cstx;
+  if (!replayer->turn_off_assert && !has_reset_inode) {
     ceph_assert(cur_entry->fh.ll_info.c_info.inode != nullptr);
     ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
   }
   // dout(0) << ": --->" << cur_entry->epath
   //         << ", in=" << cur_entry->fh.ll_info.c_inode.get() << dendl;
-  r = ceph_ll_open(replayer->m_local_mount,
-                   cur_entry->fh.ll_info.c_info.inode.get(),
-                   O_RDONLY | O_NOFOLLOW, &fh_raw, replayer->m_local_perms);
-  if (r < 0) {
-    derr << ": failed to open cur snapshot's file path="
-         << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
-                     replayer->m_cct)
-         << ": " << cpp_strerror(r) << dendl;
-    return r;
+  if (cur_entry->fh.ll_info.c_info.inode == nullptr) {
+    r = replayer->ll_reduce_gap(replayer->m_local_mount,
+                                cur_entry->fh.ll_info.c_info,
+                                replayer->m_local_perms);
+    if (r < 0) {
+      derr << ": failed to reduce gap for local cur entry="
+           << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                       replayer->m_cct)
+           << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    if (!replayer->turn_off_assert) {
+      ceph_assert(cur_entry->fh.ll_info.c_info.parent != nullptr);
+      ceph_assert(cur_entry->fh.ll_info.c_info.parent->inode != nullptr);
+      ceph_assert(!cur_entry->fh.ll_info.c_info.gap);
+    }
+    r = ceph_ll_create(replayer->m_local_mount,
+                       cur_entry->fh.ll_info.c_info.parent->inode.get(),
+                       cur_entry->fh.ll_info.c_info.path.c_str(), 0,
+                       O_RDONLY | O_NOFOLLOW, &inode_raw, &fh_raw, &cstx, 0,
+                       replayer->sync_flags, replayer->m_local_perms);
+    if (r < 0) {
+      derr << ": failed to create file handle for local cur entry="
+           << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                       replayer->m_cct)
+           << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    if (!replayer->turn_off_assert) {
+      ceph_assert(inode_raw != nullptr);
+    }
+    cur_entry->fh.ll_info.c_info.inode =
+        create_inode_shared_ptr(replayer->m_local_mount, inode_raw);
+  } else {
+    r = ceph_ll_open(replayer->m_local_mount,
+                     cur_entry->fh.ll_info.c_info.inode.get(),
+                     O_RDONLY | O_NOFOLLOW, &fh_raw, replayer->m_local_perms);
+    if (r < 0) {
+      derr << ": failed to open cur snapshot's file path="
+           << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                       replayer->m_cct)
+           << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
   }
   if (!replayer->turn_off_assert) {
     ceph_assert(fh_raw != nullptr);
@@ -1082,6 +1163,7 @@ int FileSyncMechanism::ll_copy_to_remote() {
 
   struct ceph_statx rstx;
   fh_raw = nullptr;
+  inode_raw = nullptr;
   if (cur_entry->fh.ll_info.r_info.inode == nullptr) {
     ll_populate_remote_inode_with_diff_base();
   }
@@ -1100,13 +1182,13 @@ int FileSyncMechanism::ll_copy_to_remote() {
       ceph_assert(cur_entry->fh.ll_info.r_info.parent->inode != nullptr);
       ceph_assert(!cur_entry->fh.ll_info.r_info.gap);
     }
-    InodeRawPtr inode_raw = nullptr;
-    r = ceph_ll_create(replayer->m_remote_mount,
-                       cur_entry->fh.ll_info.r_info.parent->inode.get(),
-                       cur_entry->fh.ll_info.r_info.path.c_str(),
-                       cur_entry->stx.stx_mode, O_CREAT | O_WRONLY | O_NOFOLLOW | O_TRUNC,
-                       &inode_raw, &fh_raw, &rstx, 0, replayer->sync_flags,
-                       replayer->m_remote_perms);
+    inode_raw = nullptr;
+    r = ceph_ll_create(
+        replayer->m_remote_mount,
+        cur_entry->fh.ll_info.r_info.parent->inode.get(),
+        cur_entry->fh.ll_info.r_info.path.c_str(), cur_entry->stx.stx_mode,
+        O_CREAT | O_WRONLY | O_NOFOLLOW | O_TRUNC, &inode_raw, &fh_raw, &rstx,
+        0, replayer->sync_flags, replayer->m_remote_perms);
     if (r < 0) {
       derr << ": failed to create remote file path="
            << abs_path(registry->dir_root, cur_entry->epath) << ": "
@@ -1350,8 +1432,21 @@ close_local_fd:
 
 void PeerReplayer::enqueue_file_transfer(
     FileSyncMechanism *syncm, DirRegistry *registry,
-    std::shared_ptr<SnapSyncStat> &sync_stat) {
-  registry->inc_sync_indicator();
+    std::shared_ptr<SnapSyncStat> &sync_stat,
+    std::queue<FileSyncMechanism *> *local_batch) {
+  if (reset_inode_before_submission) {
+    syncm->reset_inode();
+  }
+  if (local_batch) {
+    if (local_batch->size() >= local_batch_size) {
+      file_mirror_pool.sync_file_data(local_batch,
+                                      registry->get_file_sync_queue_idx());
+    }
+  }
+  if (enable_local_batching) {
+    local_batch->push(syncm);
+    return;
+  }
   file_mirror_pool.sync_file_data(syncm, registry->get_file_sync_queue_idx());
 }
 
@@ -1440,7 +1535,7 @@ int SyncMechanism::ll_remote_file_op() {
       FileSyncMechanism *syncm =
           new FileSyncMechanism(replayer->m_local_mount, std::move(cur_entry),
                                 registry, sync_stat, fh, replayer);
-      replayer->enqueue_file_transfer(syncm, registry, sync_stat);
+      replayer->enqueue_file_transfer(syncm, registry, sync_stat, local_batch);
       return 0;
     } else if (S_ISLNK(cstx.stx_mode)) {
       r = ll_unlink_cur_file_entry();
@@ -1515,8 +1610,8 @@ int SyncMechanism::ll_remote_file_op() {
 int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
                                  DirRegistry *registry,
                                  std::shared_ptr<SnapSyncStat> &sync_stat,
-                                 LocalSyncStat* local_stat,
-                                 const FHandles &fh) {
+                                 LocalSyncStat *local_stat, const FHandles &fh,
+                                 std::queue<FileSyncMechanism *> *local_batch) {
   bool need_data_sync = cur_entry->create_fresh() ||
                         cur_entry->purge_remote() ||
                         ((cur_entry->change_mask & CEPH_STATX_SIZE) > 0) ||
@@ -1532,7 +1627,7 @@ int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
     if (S_ISREG(cur_entry->stx.stx_mode)) {
       FileSyncMechanism *syncm = new FileSyncMechanism(
           m_local_mount, std::move(cur_entry), registry, sync_stat, fh, this);
-      enqueue_file_transfer(syncm, registry, sync_stat);
+      enqueue_file_transfer(syncm, registry, sync_stat, local_batch);
       return 0;
     } else if (S_ISLNK(cur_entry->stx.stx_mode)) {
       // free the remote link before relinking
@@ -1692,7 +1787,7 @@ int SyncMechanism::ll_cleanup_remote_entry() {
     SyncMechanism *syncm =
         new LL_DeleteMechanism(replayer->m_local_mount, std::move(d_entry),
                                registry, sync_stat, fh, replayer);
-    registry->sync_pool->sync_direct(syncm, local_stat);
+    registry->sync_pool->sync_direct(syncm, local_stat, local_batch);
   }
 
   r = ll_unlink_cur_dir_entry();
@@ -2010,7 +2105,7 @@ int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
       SyncMechanism *syncm =
           new LL_DeleteMechanism(replayer->m_local_mount, std::move(d_entry),
                                  registry, sync_stat, fh, replayer);
-      registry->sync_pool->sync_anyway(syncm, local_stat);
+      registry->sync_pool->sync_anyway(syncm, local_stat, local_batch);
     } else if (extra_flags) {
       cur_entry->cache_map[d_name] =
           PeerReplayer::CacheInfo(std::move(p_inode), pstx);
@@ -2024,7 +2119,8 @@ int PeerReplayer::propagate_deleted_entries(
     const std::string &epath, DirRegistry *registry,
     std::shared_ptr<SnapSyncStat> &sync_stat, const FHandles &fh,
     std::unordered_map<std::string, unsigned int> &change_mask_map,
-    int &change_mask_map_size, LocalSyncStat *local_stat) {
+    int &change_mask_map_size, LocalSyncStat *local_stat,
+    std::queue<FileSyncMechanism *> *local_batch) {
   dout(10) << ": dir_root=" << registry->dir_root << ", epath=" << epath
            << dendl;
   ceph_dir_result *dirp;
@@ -2114,7 +2210,7 @@ int PeerReplayer::propagate_deleted_entries(
       SyncMechanism *syncm = new DeleteMechanism(
           m_local_mount, std::move(std::make_shared<SyncEntry>(dpath)),
           registry, sync_stat, fh, this, !S_ISDIR(pstx.stx_mode));
-      registry->sync_pool->sync_anyway(syncm, local_stat);
+      registry->sync_pool->sync_anyway(syncm, local_stat, local_batch);
     } else if (extra_flags) {
       unsigned int change_mask = 0;
       build_change_mask(pstx, cstx, false, purge_remote, change_mask);
@@ -2453,11 +2549,6 @@ int PeerReplayer::sync_perms(const std::string& path) {
 }
 
 void PeerReplayer::DirSyncPool::activate() {
-  {
-    std::scoped_lock lock(mtx);
-    active = true;
-    qlimit = 1 << 15;
-  }
   for (int i = 0; i < num_threads; ++i) {
     dir_scanners.emplace_back(new DirScanner());
     dir_scanners[i]->stop_called = false;
@@ -2476,6 +2567,20 @@ void PeerReplayer::DirSyncPool::drain_queue() {
       queued--;
     }
   }
+  pick_cv.notify_all();
+}
+
+void PeerReplayer::DirSyncPool::sync_finish() {
+  std::unique_lock<std::mutex> lock(mtx);
+  active = false;
+  for (auto &dir_scanner : dir_scanners) {
+    if (!dir_scanner->local_batch.empty()) {
+      replayer->file_mirror_pool.sync_file_data(
+          &dir_scanner->local_batch, registry->get_file_sync_queue_idx());
+    }
+  }
+
+  lock.unlock();
   pick_cv.notify_all();
 }
 
@@ -2519,6 +2624,7 @@ void PeerReplayer::DirSyncPool::run(DirScanner *dir_scanner) {
       }
       task = sync_queue.front();
       task->local_stat = &dir_scanner->local_stat;
+      task->local_batch = &dir_scanner->local_batch;
       sync_queue.pop();
       queued--;
     }
@@ -2549,16 +2655,19 @@ bool PeerReplayer::DirSyncPool::try_sync(SyncMechanism *task) {
 }
 
 void PeerReplayer::DirSyncPool::sync_anyway(
-    SyncMechanism *task, LocalSyncStat *local_stat) {
+    SyncMechanism *task, LocalSyncStat *local_stat,
+    std::queue<FileSyncMechanism *> *local_batch) {
   if (!try_sync(task)) {
-    sync_direct(task, local_stat);
+    sync_direct(task, local_stat, local_batch);
   }
 }
 
 void PeerReplayer::DirSyncPool::sync_direct(
-    SyncMechanism *task, LocalSyncStat *local_stat) {
+    SyncMechanism *task, LocalSyncStat *local_stat,
+    std::queue<FileSyncMechanism *> *local_batch) {
   task->sync_in_flight();
   task->local_stat = local_stat;
+  task->local_batch = local_batch;
   task->complete(low_level);
 }
 
@@ -2632,11 +2741,12 @@ void PeerReplayer::DirSyncPool::update_qlimit(int _qlimit) {
   qlimit = _qlimit;
 }
 
-bool SyncMechanism::ll_populate_remote_inode_with_diff_base() { // need to be checked
+bool SyncMechanism::ll_populate_remote_inode_with_diff_base() { // need to be
+                                                                // checked
   if (fh.p_mnt == replayer->m_remote_mount &&
       cur_entry->fh.ll_info.r_info.inode == nullptr &&
       cur_entry->fh.ll_info.p_info.inode != nullptr &&
-      !cur_entry->fh.ll_info.p_info.gap && cur_entry->fh.ll_info.r_info.gap) {
+      !cur_entry->fh.ll_info.p_info.gap) {
     if (!replayer->turn_off_assert) {
       ceph_assert(cur_entry->fh.ll_info.p_info.parent != nullptr);
       ceph_assert(cur_entry->fh.ll_info.p_info.parent->inode != nullptr);
@@ -2930,14 +3040,12 @@ notify_finish:
 void FileSyncMechanism::finish(int r) {
   int x = 0;
   if (r < 0) {
-    goto notify_finish;
+     return;
   }
-  x = (r == 0) ? sync_file() : ll_sync_file();
+  x = ((r == 0) ? sync_file() : ll_sync_file());
   if (x < 0) {
     registry->set_failed(x);
   }
-notify_finish:
-  registry->dec_sync_indicator();
 }
 
 int FileSyncMechanism::ll_sync_file() {
@@ -3008,7 +3116,7 @@ void DirSyncMechanism::finish(int r) {
   if (r < 0) {
     goto notify_finish;
   }
-  x = (r == 0) ? sync_tree() : ll_sync_tree();
+  x = ((r == 0) ? sync_tree() : ll_sync_tree());
   if (x < 0) {
     registry->set_failed(x);
   }
@@ -3086,6 +3194,9 @@ void PeerReplayer::SyncEntry::rollout(FHandles &parent_fh,
     ceph_assert(parent_fh.ll_info.r_info.parent != nullptr);
     ceph_assert(parent_fh.ll_info.r_info.parent->inode != nullptr);
   }
+  fh.ll_info.c_info.inode = nullptr;
+  fh.ll_info.p_info.inode = nullptr;
+  fh.ll_info.r_info.inode = nullptr;
   if (parent_fh.ll_info.c_info.inode != nullptr) {
     if (!replayer->turn_off_assert) {
       ceph_assert(!parent_fh.ll_info.c_info.gap);
@@ -3188,7 +3299,7 @@ int DirSnapDiffSync::ll_go_next() {
         SyncMechanism *syncm = new LL_DeleteMechanism(
             replayer->m_local_mount, std::move(deleted_entry), registry,
             sync_stat, fh, replayer);
-        registry->sync_pool->sync_anyway(syncm, local_stat);
+        registry->sync_pool->sync_anyway(syncm, local_stat, local_batch);
         entry->deleted_sibling_exist = false;
       }
     }
@@ -3284,7 +3395,7 @@ int DirSnapDiffSync::go_next() {
         SyncMechanism *syncm = new DeleteMechanism(
             m_local, std::move(deleted_entry), registry, sync_stat, fh,
             replayer, (DT_DIR != entry->deleted_sibling.dir_entry.d_type));
-        registry->sync_pool->sync_anyway(syncm, local_stat);
+        registry->sync_pool->sync_anyway(syncm, local_stat, local_batch);
         entry->deleted_sibling_exist = false;
       }
     }
@@ -3374,7 +3485,7 @@ int DirSnapDiffSync::ll_sync_current_entry() {
     syncm = new DirBruteDiffSync(
         replayer->m_local_mount, std::move(cur_entry), registry, sync_stat,
         failed_prev ? registry->remotediff_fh : fh, replayer);
-    registry->sync_pool->sync_direct(syncm, local_stat);
+    registry->sync_pool->sync_direct(syncm, local_stat, local_batch);
     cur_entry = nullptr;
     return 0;
   }
@@ -3500,7 +3611,7 @@ int DirSnapDiffSync::sync_current_entry() {
     syncm = new DirBruteDiffSync(
         m_local, std::move(cur_entry), registry, sync_stat,
         failed_prev ? registry->remotediff_fh : fh, replayer);
-    registry->sync_pool->sync_direct(syncm, local_stat);
+    registry->sync_pool->sync_direct(syncm, local_stat, local_batch);
     return 0;
   }
 
@@ -3513,7 +3624,7 @@ int DirSnapDiffSync::sync_current_entry() {
                                       replayer->stat_flush_counter_gap);
   } else {
     r = replayer->remote_file_op(cur_entry, registry, sync_stat, local_stat,
-                                 fh);
+                                 fh, local_batch);
     cur_entry = nullptr;
     return r;
   }
@@ -3777,7 +3888,7 @@ int DirBruteDiffSync::ll_sync_current_entry() {
     SyncMechanism *syncm = new DirBruteDiffSync(
         replayer->m_local_mount, std::move(cur_entry), registry, sync_stat,
         registry->remotediff_fh, replayer);
-    registry->sync_pool->sync_direct(syncm, local_stat);
+    registry->sync_pool->sync_direct(syncm, local_stat, local_batch);
     cur_entry = nullptr;
     return 0;
   }
@@ -3802,7 +3913,7 @@ int DirBruteDiffSync::ll_sync_current_entry() {
   if (cur_entry->purge_remote()) {
     SyncMechanism *syncm = new LL_DeleteMechanism(
         replayer->m_local_mount, cur_entry, registry, sync_stat, fh, replayer);
-    registry->sync_pool->sync_direct(syncm, local_stat);
+    registry->sync_pool->sync_direct(syncm, local_stat, local_batch);
     cur_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
     cur_entry->fh.ll_info.r_info.inode = nullptr;
   }
@@ -3890,7 +4001,7 @@ int DirBruteDiffSync::sync_current_entry() {
     SyncMechanism *syncm =
         new DirBruteDiffSync(m_local, std::move(cur_entry), registry, sync_stat,
                              registry->remotediff_fh, replayer);
-    registry->sync_pool->sync_direct(syncm, local_stat);
+    registry->sync_pool->sync_direct(syncm, local_stat, local_batch);
     return 0;
   }
 
@@ -3913,8 +4024,8 @@ int DirBruteDiffSync::sync_current_entry() {
     local_stat->inc_dir_scanned_count(sync_stat->current_stat,
                                       replayer->stat_flush_counter_gap);
   } else {
-    r = replayer->remote_file_op(cur_entry, registry, sync_stat, local_stat,
-                                 fh);
+    r = replayer->remote_file_op(cur_entry, registry, sync_stat, local_stat, fh,
+                                 local_batch);
     cur_entry = nullptr;
     return r;
   }
@@ -3934,9 +4045,9 @@ int DirBruteDiffSync::sync_current_entry() {
   */
 
   if (!cur_entry->create_fresh() && !cur_entry->purge_remote()) {
-    r = replayer->propagate_deleted_entries(cur_entry->epath, registry,
-                                            sync_stat, fh, change_mask_map,
-                                            change_mask_map_size, local_stat);
+    r = replayer->propagate_deleted_entries(
+        cur_entry->epath, registry, sync_stat, fh, change_mask_map,
+        change_mask_map_size, local_stat, local_batch);
     if (r < 0 && r != -ENOENT) {
       derr << ": failed to propagate missing dirs: " << cpp_strerror(r)
            << dendl;
@@ -4005,7 +4116,7 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
                                     const Snapshot &current,
                                     boost::optional<Snapshot> prev) {
   dout(0)
-      << ": cephfs_mirror_file_sync_thread="
+      << "cephfs_mirror_file_sync_thread="
       << g_ceph_context->_conf.get_val<uint64_t>(
              "cephfs_mirror_file_sync_thread")
       << ", cephfs_mirror_dir_scanning_thread=" << dir_scanning_thread
@@ -4019,6 +4130,10 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
       << ", cephfs_mirror_max_concurrent_directory_syncs="
       << max_concurrent_directory_syncs
       << ", cephfs_mirror_use_snapdiff_api=" << use_snapdiff_api
+      << ", cephfs_mirror_lock_directory_before_sync="
+      << lock_directory_before_sync
+      << ", cephfs_mirror_remote_timeout=" << remote_timeout
+      << ", cephfs_mirror_local_timeout=" << local_timeout
       << ", mds_session_blocklist_on_timeout="
       << g_ceph_context->_conf.get_val<bool>("mds_session_blocklist_on_timeout")
       << ", mds_session_blocklist_on_evict="
@@ -4029,7 +4144,7 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
       << g_ceph_context->_conf.get_val<std::chrono::seconds>(
              "client_tick_interval")
       << ", client_cache_size=" << g_ceph_context->_conf->client_cache_size
-      << ", cephfs_mirror_max_consecutive_failures_before_remote_sync= "
+      << ", cephfs_mirror_max_consecutive_failures_before_remote_sync="
       << max_consecutive_failures_before_remote_sync
       << ", cephfs_mirror_skip_error=" << skip_error
       << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
@@ -4037,7 +4152,11 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
       << ", cephfs_mirror_stat_flush_counter_gap=" << stat_flush_counter_gap
       << ", cephfs_mirror_turn_off_assert=" << turn_off_assert
       << ", cephfs_mirror_snap_prefix=" << snap_prefix
-      << ", cephfs_mirror_sync_from_remote=" << sync_from_remote << dendl;
+      << ", cephfs_mirror_sync_from_remote=" << sync_from_remote
+      << ", cephfs_mirror_enable_local_batching=" << enable_local_batching
+      << ", cephfs_mirror_local_batch_size=" << local_batch_size
+      << ", cephfs_mirror_reset_inode_before_submission=" << reset_inode_before_submission
+      << dendl;
   // ceph_assert(sync_flags == AT_SYMLINK_NOFOLLOW);
   // sync_flags = AT_SYMLINK_NOFOLLOW;
 
@@ -4074,7 +4193,8 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
   sync_stat->current_stat.rbytes = rbytes;
   sync_stat->current_stat.start_timer();
   registry->sync_pool = std::make_unique<DirSyncPool>(
-      dir_scanning_thread, dir_root, m_peer, sync_stat);
+      dir_scanning_thread, thread_pool_queue_size, dir_root, m_peer, sync_stat,
+      this, registry);
   registry->sync_pool->set_low_level(true);
   registry->sync_pool->activate();
   lock.unlock();
@@ -4114,29 +4234,31 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
                                  sync_stat, registry->remotediff_fh, this);
   }
   LocalSyncStat local_stat;
-  registry->sync_pool->sync_anyway(syncm, &local_stat);
+  std::queue <FileSyncMechanism*> local_batch;
+  registry->sync_pool->sync_anyway(syncm, &local_stat, &local_batch);
   registry->wait_for_sync_finish();
 
-  should_backoff(registry, &r);
-  if (registry->failed) {
-    r = registry->failed_reason;
-  }
-
-  lock.lock();
+  registry->sync_pool->sync_finish();
   file_mirror_pool.sync_finish(registry->get_file_sync_queue_idx(), dir_root);
+  lock.lock();
   registry->file_sync_queue_idx = -2;
   registry->sync_pool->deactivate();
   registry->sync_pool = nullptr;
   // sync_stat->reset_stats(r);
   lock.unlock();
-  dout(0) << ": sync done-->" << dir_root << ", " << current.first << dendl;
+  should_backoff(registry, &r);
+  if (registry->failed) {
+    r = registry->failed_reason;
+  }
+  dout(0) << ": sync done-->" << dir_root << ", " << current.first
+          << ", r=" << r << dendl;
   return r;
 }
 
 int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &current,
                                  boost::optional<Snapshot> prev) {
   dout(0)
-      << ":cephfs_mirror_file_sync_thread="
+      << "cephfs_mirror_file_sync_thread="
       << g_ceph_context->_conf.get_val<uint64_t>(
              "cephfs_mirror_file_sync_thread")
       << ", cephfs_mirror_dir_scanning_thread=" << dir_scanning_thread
@@ -4150,6 +4272,10 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       << ", cephfs_mirror_max_concurrent_directory_syncs="
       << max_concurrent_directory_syncs
       << ", cephfs_mirror_use_snapdiff_api=" << use_snapdiff_api
+      << ", cephfs_mirror_lock_directory_before_sync="
+      << lock_directory_before_sync
+      << ", cephfs_mirror_remote_timeout=" << remote_timeout
+      << ", cephfs_mirror_local_timeout=" << local_timeout
       << ", mds_session_blocklist_on_timeout="
       << g_ceph_context->_conf.get_val<bool>("mds_session_blocklist_on_timeout")
       << ", mds_session_blocklist_on_evict="
@@ -4160,7 +4286,7 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       << g_ceph_context->_conf.get_val<std::chrono::seconds>(
              "client_tick_interval")
       << ", client_cache_size=" << g_ceph_context->_conf->client_cache_size
-      << ", cephfs_mirror_max_consecutive_failures_before_remote_sync= "
+      << ", cephfs_mirror_max_consecutive_failures_before_remote_sync="
       << max_consecutive_failures_before_remote_sync
       << ", cephfs_mirror_skip_error=" << skip_error
       << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
@@ -4168,7 +4294,11 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       << ", cephfs_mirror_stat_flush_counter_gap=" << stat_flush_counter_gap
       << ", cephfs_mirror_turn_off_assert=" << turn_off_assert
       << ", cephfs_mirror_snap_prefix=" << snap_prefix
-      << ", cephfs_mirror_sync_from_remote=" << sync_from_remote << dendl;
+      << ", cephfs_mirror_sync_from_remote=" << sync_from_remote
+      << ", cephfs_mirror_enable_local_batching=" << enable_local_batching
+      << ", cephfs_mirror_local_batch_size=" << local_batch_size
+      << ", cephfs_mirror_reset_inode_before_submission=" << reset_inode_before_submission
+      << dendl;
 
   dout(0) << ": sync start-->" << dir_root << ",cur_snap= " << current.first
           << ", diff_base=" << (prev ? (*prev).first : "remote") << dendl;
@@ -4262,7 +4392,8 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
   sync_stat->current_stat.rbytes = std::stoull(rbytes);
   sync_stat->current_stat.start_timer();
   registry->sync_pool = std::make_unique<DirSyncPool>(
-      dir_scanning_thread, dir_root, m_peer, sync_stat);
+      dir_scanning_thread, thread_pool_queue_size, dir_root, m_peer, sync_stat,
+      this, registry);
   registry->sync_pool->activate();
   lock.unlock();
 
@@ -4305,8 +4436,18 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
                                  sync_stat, registry->remotediff_fh, this);
   }
   LocalSyncStat local_stat;
-  registry->sync_pool->sync_anyway(syncm, &local_stat);
+  std::queue <FileSyncMechanism*> local_batch;
+  registry->sync_pool->sync_anyway(syncm, &local_stat, &local_batch);
   registry->wait_for_sync_finish();
+
+  registry->sync_pool->sync_finish();
+  file_mirror_pool.sync_finish(registry->get_file_sync_queue_idx(), dir_root);
+  lock.lock();
+  registry->file_sync_queue_idx = -2;
+  registry->sync_pool->deactivate();
+  registry->sync_pool = nullptr;
+  lock.unlock();
+
   if (!prev || registry->snapdiff_fh.p_fd < 0 || !use_snapdiff_api) {
     if (root_entry->dirp &&
         ceph_closedir(m_local_mount, root_entry->dirp) < 0) {
@@ -4320,13 +4461,6 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
   if (registry->failed) {
     r = registry->failed_reason;
   }
-
-  lock.lock();
-  file_mirror_pool.sync_finish(registry->get_file_sync_queue_idx(), dir_root);
-  registry->file_sync_queue_idx = -2;
-  registry->sync_pool->deactivate();
-  registry->sync_pool = nullptr;
-  lock.unlock();
 
   dout(20) << " cur:" << fh->c_fd
            << " prev:" << fh->p_fd

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1772,6 +1772,7 @@ int SyncMechanism::ll_cleanup_remote_entry() {
     }
     auto d_name = std::string(de.d_name);
     if (d_name == "." || d_name == "..") {
+      ceph_ll_forget(replayer->m_remote_mount, r_inode_raw, 1);
       continue;
     }
     std::shared_ptr<PeerReplayer::SyncEntry> d_entry =
@@ -2064,6 +2065,7 @@ int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
     }
     std::string d_name = de.d_name;
     if (d_name == "." || d_name == "..") {
+      ceph_ll_forget(fh.p_mnt, p_inode_raw, 1);
       continue;
     }
     if (!replayer->turn_off_assert) {
@@ -2549,6 +2551,10 @@ int PeerReplayer::sync_perms(const std::string& path) {
 }
 
 void PeerReplayer::DirSyncPool::activate() {
+  {
+    std::scoped_lock lock(mtx);
+    active = true;
+  }
   for (int i = 0; i < num_threads; ++i) {
     dir_scanners.emplace_back(new DirScanner());
     dir_scanners[i]->stop_called = false;
@@ -2932,7 +2938,7 @@ int SyncMechanism::ll_populate_prev_stat_and_prev_inode() {
     r = replayer->ll_open_inode(
         fh.p_mnt, cur_entry->fh.ll_info.p_info, cur_entry->pstx,
         (cur_entry->pstat_known ? 0 : mask), fh.ll_info.p_perms);
-    if (!replayer->turn_off_assert) {
+    if (!replayer->turn_off_assert && r == 0) {
       ceph_assert(!cur_entry->fh.ll_info.p_info.gap);
     }
     if (r < 0 && r != -ENOENT) {
@@ -3137,14 +3143,13 @@ int DirSyncMechanism::ll_sync_tree() {
         break;
       }
     }
+    cur_entry = nullptr;
     r = ll_go_next();
     if (r < 0) {
       r1 = r;
       break;
     }
   }
-finish:
-  ll_finish_sync();
   return r1;
 }
 
@@ -3248,94 +3253,39 @@ int DirSnapDiffSync::ll_go_next() {
     std::shared_ptr<PeerReplayer::SyncEntry> &entry = m_sync_stack.top();
     dout(20) << ": top of stack path=" << entry->epath << dendl;
     std::string e_name;
-    ceph_snapdiff_entry_t sd_entry;
-    bool failed = false;
-    while (true) {
-      r = 0;
-      if (replayer->should_backoff(registry, &r)) {
-        return r;
-      }
-      r = ceph_readdir_snapdiff(&entry->info, &sd_entry);
-      if (r < 0) {
-        derr << ": failed to read snapdiff entry between snapdiff of local "
-                "snapshot's cur entry="
-             << abs_path(registry->dir_root, entry->epath, fh.m_current.first,
-                         replayer->m_cct)
-             << "and diff base's cur entry="
-             << abs_path(registry->dir_root, entry->epath, (*fh.m_prev).first,
-                         replayer->m_cct)
-             << ": " << cpp_strerror(r) << dendl;
-        if (replayer->skip_error) {
-          registry->set_failed(r);
-          failed = true;
-          r = 0; break;
-        }
-        return r;
-      }
-      if (r == 0) {
-        break;
-      }
-      std::string d_name = sd_entry.dir_entry.d_name;
-      if (d_name == "." || d_name == "..") {
-        continue;
-      }
-      e_name = d_name;
-      break;
+    int d_status, d_type;
+    r = 0;
+    if (replayer->should_backoff(registry, &r)) {
+      return r;
     }
-    std::string epath = std::move(entry_path(entry->epath, e_name));
-
-    if (entry->deleted_sibling_exist && !failed) {
-      ceph_assert(entry->deleted_sibling.snapid == (*fh.m_prev).second);
-      std::string deleted_sibling_d_name =
-          entry->deleted_sibling.dir_entry.d_name;
-      if (r == 0 || sd_entry.snapid == (*fh.m_prev).second ||
-          e_name != deleted_sibling_d_name) {
-        std::shared_ptr<PeerReplayer::SyncEntry> deleted_entry =
-            std::make_shared<PeerReplayer::SyncEntry>(
-                std::move(entry_path(entry->epath, deleted_sibling_d_name)));
-        deleted_entry->rollout(entry->fh, deleted_sibling_d_name, replayer);
-        deleted_entry->prev_d_type =
-            (int)deleted_entry->deleted_sibling.dir_entry.d_type;
-        SyncMechanism *syncm = new LL_DeleteMechanism(
-            replayer->m_local_mount, std::move(deleted_entry), registry,
-            sync_stat, fh, replayer);
-        registry->sync_pool->sync_anyway(syncm, local_stat, local_batch);
-        entry->deleted_sibling_exist = false;
-      }
-    }
-    if (r == 0) {
-      dout(10) << ": done for directory=" << entry->epath << dendl;
-      r = ceph_close_snapdiff(&entry->info);
-      if (r < 0) {
-        derr << ": failed to close snapdiff info between snapdiff of local "
-                "snapshot's cur entry="
-             << abs_path(registry->dir_root, entry->epath, fh.m_current.first,
-                         replayer->m_cct)
-             << "and diff base's cur entry="
-             << abs_path(registry->dir_root, entry->epath, (*fh.m_prev).first,
-                         replayer->m_cct)
-             << ": " << cpp_strerror(r) << dendl;
-      }
-      r = 0;
+    if (entry->snapdiff_map.empty()) {
       m_sync_stack.pop();
       continue;
     }
-
-    if (sd_entry.snapid == (*fh.m_prev).second) {
-      entry->deleted_sibling = sd_entry;
-      entry->deleted_sibling_exist = true;
+    auto it = entry->snapdiff_map.begin();
+    e_name = it->first;
+    d_status = it->second.first;
+    d_type = it->second.second;
+    entry->snapdiff_map.erase(it);
+    if (d_status == -1) {
+      std::shared_ptr<PeerReplayer::SyncEntry> deleted_entry =
+          std::make_shared<PeerReplayer::SyncEntry>(
+              std::move(entry_path(entry->epath, e_name)));
+      deleted_entry->rollout(entry->fh, e_name, replayer);
+      deleted_entry->prev_d_type = d_type;
+      SyncMechanism *syncm = new LL_DeleteMechanism(
+          replayer->m_local_mount, std::move(deleted_entry), registry,
+          sync_stat, fh, replayer);
+      registry->sync_pool->sync_anyway(syncm, local_stat, local_batch);
       continue;
     }
     std::shared_ptr<PeerReplayer::SyncEntry> d_entry =
-        std::make_shared<PeerReplayer::SyncEntry>(std::move(epath));
+        std::make_shared<PeerReplayer::SyncEntry>(
+            std::move(entry_path(entry->epath, e_name)));
     d_entry->rollout(entry->fh, e_name, replayer);
-    if (entry->deleted_sibling_exist &&
-        sd_entry.snapid == fh.m_current.second &&
-        e_name == entry->deleted_sibling.dir_entry.d_name) {
-      ceph_assert(entry->deleted_sibling.snapid == (*fh.m_prev).second);
+    if (d_status == 0) {
       d_entry->change_mask |= PeerReplayer::SyncEntry::PURGE_REMOTE;
-      d_entry->prev_d_type = (int)entry->deleted_sibling.dir_entry.d_type;
-      entry->deleted_sibling_exist = false;
+      d_entry->prev_d_type = d_type;
     }
     SyncMechanism *syncm =
         new DirSnapDiffSync(replayer->m_local_mount, std::move(d_entry),
@@ -3549,11 +3499,65 @@ int DirSnapDiffSync::ll_sync_current_entry() {
          << ": " << cpp_strerror(r) << dendl;
     return r;
   }
-  cur_entry->is_snapdiff = true;
-  cur_entry->set_remote_synced();
-  m_sync_stack.emplace(std::move(cur_entry));
+  ceph_snapdiff_entry_t sd_entry;
+  auto& snapdiff_map = cur_entry->snapdiff_map;
+  while (true) {
+    r = 0;
+    if (replayer->should_backoff(registry, &r)) {
+      break;
+    }
+    r = ceph_readdir_snapdiff(&cur_entry->info, &sd_entry);
+    if (r < 0) {
+      derr << ": failed to read snapdiff entry between snapdiff of local "
+              "snapshot's cur entry="
+           << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                       replayer->m_cct)
+           << "and diff base's cur entry="
+           << abs_path(registry->dir_root, cur_entry->epath, (*fh.m_prev).first,
+                       replayer->m_cct)
+           << ": " << cpp_strerror(r) << dendl;
+      break;
+    }
+    if (r == 0) {
+      break;
+    }
+    std::string d_name = sd_entry.dir_entry.d_name;
+    if (d_name == "." || d_name == "..") {
+      continue;
+    }
+    auto it = snapdiff_map.find(d_name);
+    if (it == snapdiff_map.end()) {
+      snapdiff_map[d_name] = {
+          ((sd_entry.snapid == (*fh.m_prev).second) ? -1 : +1),
+          ((sd_entry.snapid == (*fh.m_prev).second)
+               ? (int)sd_entry.dir_entry.d_type
+               : -1)};
+    } else {
+      if (it->second.first == 0 ||
+          (it->second.first == -1 && sd_entry.snapid == (*fh.m_prev).second) ||
+          (it->second.first == +1 && sd_entry.snapid == fh.m_current.second)) {
+        continue;
+      }
+      it->second.first = 0;
+      if (sd_entry.snapid == (*fh.m_prev).second) {
+        it->second.second = (int)sd_entry.dir_entry.d_type;
+      }
+    }
+  }
+  int close_err = ceph_close_snapdiff(&cur_entry->info);
+  if (close_err < 0) {
+    derr << ": failed to close snapdiff for directory="
+         << abs_path(registry->dir_root, cur_entry->epath, fh.m_current.first,
+                     replayer->m_cct)
+         << ": " << cpp_strerror(close_err) << dendl;
+  }
+  if (r == 0) {
+    cur_entry->is_snapdiff = true;
+    cur_entry->set_remote_synced();
+    m_sync_stack.emplace(std::move(cur_entry));
+  }
   cur_entry = nullptr;
-  return 0;
+  return r < 0 ? r : 0;
 }
 
 int DirSnapDiffSync::sync_current_entry() {
@@ -3642,22 +3646,6 @@ int DirSnapDiffSync::sync_current_entry() {
   return 0;
 }
 
-void DirSnapDiffSync::ll_finish_sync() {
-  while (!m_sync_stack.empty()) {
-    auto &entry = m_sync_stack.top();
-    if (entry->is_snapdiff) {
-      int r = ceph_close_snapdiff(&(entry->info));
-      if (r < 0) {
-        derr << ": failed to close snapdiff for directory="
-             << abs_path(registry->dir_root, entry->epath, fh.m_current.first,
-                         replayer->m_cct)
-             << ": " << cpp_strerror(r) << dendl;
-      }
-    }
-    m_sync_stack.pop();
-  }
-}
-
 void DirSnapDiffSync::finish_sync() {
 
   while (!m_sync_stack.empty()) {
@@ -3709,6 +3697,7 @@ int DirBruteDiffSync::ll_go_next() {
       }
       auto d_name = std::string(de.d_name);
       if (d_name == "." || d_name == "..") {
+        ceph_ll_forget(replayer->m_local_mount, c_inode_raw, 1);
         continue;
       }
       e_name = d_name;
@@ -4587,11 +4576,12 @@ void PeerReplayer::sync_directory(
   if (last_snap.second != cur_snap.second) {
     dout(10) << ": synchronizing snap-id=" << cur_snap.second
              << "of directory=" << dir_root << dendl;
-    dout(0) << ": cur_snap.first=" << cur_snap.first << ", "
+    dout(0) << ": dir_root=" << dir_root
+            << ", cur_snap.first=" << cur_snap.first << ", "
             << "cur_snap.second=" << cur_snap.second
             << ", last_snap.first=" << last_snap.first
             << ", last_snap.second=" << last_snap.second << dendl;
-    r = _do_sync_snaps(dir_root, cur_snap, last_snap);    
+    r = _do_sync_snaps(dir_root, cur_snap, last_snap);
   }
 
 

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -4670,7 +4670,7 @@ int PeerReplayer::get_candidate_snap(
   }
 
   if (sync_latest_snapshot) {
-    if (it == local_snap_map.end()) {
+    if (!local_snap_map.empty() && it == local_snap_map.end()) {
       it = prev(local_snap_map.end());
       for (;; it--) {
         if (it->second.starts_with(snap_prefix)) {
@@ -4707,7 +4707,13 @@ int PeerReplayer::get_candidate_snap(
   }
 
   if (last_snap.second != cur_snap.second) {
-    dout(0) << ": diff_base=" << diff_base
+    dout(0) << ": dir=" << dir_root << ", diff_base=" << diff_base
+            << ", last_snap_id=" << last_snap.second
+            << ", dirty_snap_id=" << dirty_snap_id
+            << ", cur_snap_id=" << cur_snap.second << dendl;
+  }
+  else {
+    dout(2) << ": dir=" << dir_root << ", diff_base=" << diff_base
             << ", last_snap_id=" << last_snap.second
             << ", dirty_snap_id=" << dirty_snap_id
             << ", cur_snap_id=" << cur_snap.second << dendl;
@@ -4936,6 +4942,11 @@ void PeerReplayer::run_scan() {
                                m_directories.size() > m_registered.size() &&
                                !m_directories.empty());
     });
+    dout(2) << ": 1-->start_syncing=" << start_syncing
+            << ", nr_replayers=" << nr_replayers
+            << ", total_directories=" << m_directories.size()
+            << ", registered_directories=" << m_registered.size()
+            << ", idx=" << idx << dendl;
     if (is_stopping()) {
       dout(5) << ": exiting" << dendl;
       break;
@@ -4959,6 +4970,11 @@ void PeerReplayer::run_scan() {
       dout(5) << ": exiting" << dendl;
       break;
     }
+    dout(2) << ": 2-->start_syncing=" << start_syncing
+            << ", nr_replayers=" << nr_replayers
+            << ", total_directories=" << m_directories.size()
+            << ", registered_directories=" << m_registered.size()
+            << ", idx=" << idx << dendl;
 
     if (!(start_syncing && nr_replayers > 0 &&
           m_directories.size() > m_registered.size() &&
@@ -4986,11 +5002,21 @@ void PeerReplayer::run_scan() {
         idx = (int)m_directories.size() - 1;
       }
     }
+    dout(2) << ": 3-->start_syncing=" << start_syncing
+            << ", nr_replayers=" << nr_replayers
+            << ", total_directories=" << m_directories.size()
+            << ", registered_directories=" << m_registered.size()
+            << ", idx=" << idx << dendl;
 
     for (int i = 0; i < (int)m_directories.size() && nr_replayers > 0 &&
                     m_directories.size() > m_registered.size();
          ++i, idx = (idx + 1) % m_directories.size()) {
       next_dir = m_directories[idx];
+      dout(2) << ": 4-->start_syncing=" << start_syncing
+              << ", nr_replayers=" << nr_replayers
+              << ", total_directories=" << m_directories.size()
+              << ", registered_directories=" << m_registered.size()
+              << ", idx=" << idx << ", next_dir=" << next_dir << dendl;
       // dout(0) << "idx=" << idx << ", next_dir=" << next_dir
       //         << ", registered=" << m_registered.size()
       //         << ", total=" << m_directories.size() << dendl;
@@ -5039,6 +5065,11 @@ void PeerReplayer::run_scan() {
       }
     }
     next_dir = m_directories[idx];
+    dout(2) << ": 5-->start_syncing=" << start_syncing
+            << ", nr_replayers=" << nr_replayers
+            << ", total_directories=" << m_directories.size()
+            << ", registered_directories=" << m_registered.size()
+            << ", idx=" << idx << ", next_dir=" << next_dir << dendl;
     last_scan = clock::now();
   }
 }

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -286,6 +286,8 @@ PeerReplayer::PeerReplayer(
       "cephfs_mirror_use_at_statx_dont_sync");
   sync_flags =
       (use_at_statx_dont_sync ? AT_STATX_DONT_SYNC : 0) | AT_SYMLINK_NOFOLLOW;
+  stat_flush_counter_gap = g_ceph_context->_conf.get_val<uint64_t>(
+        "cephfs_mirror_stat_flush_counter_gap");
 }
 
 PeerReplayer::~PeerReplayer() {
@@ -428,6 +430,10 @@ void PeerReplayer::handle_conf_change(const ConfigProxy &conf,
     sync_flags =
         (use_at_statx_dont_sync ? AT_STATX_DONT_SYNC : 0) | AT_SYMLINK_NOFOLLOW;
   }
+  if (changed.count("cephfs_mirror_stat_flush_counter_gap")) {
+    stat_flush_counter_gap = g_ceph_context->_conf.get_val<uint64_t>(
+        "cephfs_mirror_stat_flush_counter_gap");
+  }
 
   m_cond.notify_all();
   dout(0)
@@ -464,6 +470,7 @@ void PeerReplayer::handle_conf_change(const ConfigProxy &conf,
       << ", cephfs_mirror_skip_error=" << skip_error
       << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
       << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
+      << ", cephfs_mirror_stat_flush_counter_gap=" << stat_flush_counter_gap
       << dendl;
 }
 
@@ -483,6 +490,7 @@ const char **PeerReplayer::get_tracked_conf_keys() const {
                                "cephfs_mirror_skip_error",
                                "cephfs_mirror_use_low_level_api",
                                "cephfs_mirror_use_at_statx_dont_sync",
+                               "cephfs_mirror_stat_flush_counter_gap",
                                NULL};
   return KEYS;
 }
@@ -582,40 +590,27 @@ int PeerReplayer::init() {
 }
 
 void PeerReplayer::shutdown() {
-  dout(20) << dendl;
-
   std::unique_lock locker(m_lock);
   ceph_assert(!m_stopping);
   m_stopping = true;
-  for (auto &[dir_root, registry] : m_registered) {
-    int sync_idx = registry->get_file_sync_queue_idx();
-    if (sync_idx >= 0) {
-      file_mirror_pool.drain_queue(sync_idx);
-    }
-    if (registry->sync_pool) {
-      registry->sync_pool->deactivate();
-    }
-    if (sync_idx >= 0) {
-      file_mirror_pool.sync_finish(sync_idx, dir_root);
-    }
-  }
-  dout(0) << ": Directory scanning thread pools deactivated" << dendl;
   locker.unlock();
-
+  file_mirror_pool.deactivate();
+  dout(20) << dendl;
   {
     std::scoped_lock thread_map_locker(thread_map_lock);
-    for (auto &[dir_root, thread_ptr] : thread_map) {
+    for (auto &[dir, thread_ptr] : thread_map) {
       thread_ptr->join();
     }
-    thread_map.clear();
+    dout(0) << ": All threads joined" << dendl;
   }
-
-  locker.lock();
   m_cond.notify_all();
-  locker.unlock();
 
   scanner_thread->join();
+  dout(0) << ": scanner threads joined" << dendl;
 
+  locker.lock();
+  m_local_root_inode = nullptr;
+  m_remote_root_inode = nullptr;
   ceph_unmount(m_remote_mount);
   ceph_release(m_remote_mount);
   m_remote_mount = nullptr;
@@ -683,6 +678,8 @@ void PeerReplayer::unregister_directory(const std::string &dir_root) {
   ceph_assert(it != m_registered.end());
 
   unlock_directory(it->first, it->second);
+  delete it->second;
+  it->second = nullptr;
   m_registered.erase(it);
   if (std::find(m_directories.begin(), m_directories.end(), dir_root) == m_directories.end()) {
     m_snap_sync_stats.erase(dir_root);
@@ -948,7 +945,8 @@ int PeerReplayer::sync_attributes(std::shared_ptr<SyncEntry> &cur_entry,
 
 int PeerReplayer::_remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
                                 const FHandles &fh,
-                                std::shared_ptr<SnapSyncStat> &sync_stat) {
+                                std::shared_ptr<SnapSyncStat> &sync_stat,
+                                LocalSyncStat *local_stat) {
   int r =
       ceph_mkdirat(m_remote_mount, fh.r_fd_dir_root, cur_entry->epath.c_str(),
                    cur_entry->stx.stx_mode & ~S_IFDIR);
@@ -958,7 +956,8 @@ int PeerReplayer::_remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
     return r;
   }
   if (r == 0) {
-    sync_stat->current_stat.inc_dir_created_count();
+    local_stat->inc_dir_created_count(sync_stat->current_stat,
+                                      stat_flush_counter_gap);
   }
   return 0;
 }
@@ -980,14 +979,16 @@ int SyncMechanism::ll_remote_mkdir() {
   ceph_assert(raw_inode != nullptr);
   cur_entry->fh.ll_info.r_inode =
       create_inode_shared_ptr(replayer->m_remote_mount, raw_inode);
-  sync_stat->current_stat.inc_dir_created_count();
+  local_stat->inc_dir_created_count(sync_stat->current_stat,
+                                    replayer->stat_flush_counter_gap);
   // dout(0) << ": --->" << cur_entry->epath << dendl;
   return 0;
 }
 
 int PeerReplayer::remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
                                const FHandles &fh,
-                               std::shared_ptr<SnapSyncStat> &sync_stat) {
+                               std::shared_ptr<SnapSyncStat> &sync_stat,
+                               LocalSyncStat* local_stat) {
   dout(10) << ": remote epath=" << cur_entry->epath << dendl;
   int r = 0;
   /*
@@ -996,7 +997,7 @@ int PeerReplayer::remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
     sync_attributes, thus saving a ceph_mkdirat call.
   */
   // if (cur_entry->create_fresh() || cur_entry->purge_remote()) {
-  r = _remote_mkdir(cur_entry, fh, sync_stat);
+  r = _remote_mkdir(cur_entry, fh, sync_stat, local_stat);
   if (r < 0) {
     return r;
   }
@@ -1138,7 +1139,6 @@ int FileSyncMechanism::ll_copy_to_remote() {
          << cpp_strerror(r) << dendl;
     goto free_ptr;
   }
-  sync_stat->current_stat.inc_file_data_synced_count(cur_entry->stx.stx_size);
 free_ptr:
   free(ptr);
   // dout(0) << ": 2--->" << cur_entry->epath << dendl;
@@ -1273,7 +1273,6 @@ close_local_fd:
 void PeerReplayer::enqueue_file_transfer(
     FileSyncMechanism *syncm, DirRegistry *registry,
     std::shared_ptr<SnapSyncStat> &sync_stat) {
-  sync_stat->current_stat.inc_file_in_flight_count();
   registry->inc_sync_indicator();
   file_mirror_pool.sync_file_data(syncm, registry->get_file_sync_queue_idx());
 }
@@ -1291,7 +1290,8 @@ int SyncMechanism::ll_unlink_cur_file_entry() {
   if (fh.p_mnt == replayer->m_remote_mount) {
     cur_entry->fh.ll_info.p_inode = nullptr;
   }
-  sync_stat->current_stat.inc_file_del_count();
+  local_stat->inc_files_deleted_count(sync_stat->current_stat,
+                                      replayer->stat_flush_counter_gap);
   // dout(0) << ": --->" << cur_entry->epath << dendl;
   return 0;
 }
@@ -1310,7 +1310,8 @@ int SyncMechanism::ll_unlink_cur_dir_entry() {
     cur_entry->fh.ll_info.p_inode = nullptr;
   }
   // dout(0) << ": --->" << cur_entry->epath << dendl;
-  sync_stat->current_stat.inc_dir_deleted_count();
+  local_stat->inc_dir_deleted_count(sync_stat->current_stat,
+                                    replayer->stat_flush_counter_gap);
   return 0;
 }
 
@@ -1380,7 +1381,7 @@ int SyncMechanism::ll_remote_file_op() {
             create_inode_shared_ptr(replayer->m_remote_mount, link_raw);
       }
       cur_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
-      sync_stat->current_stat.inc_file_data_synced_count(cstx.stx_size);
+      sync_stat->current_stat.inc_symlink_synced_count();
     } else {
       dout(5) << ": skipping entry=" << cur_entry->epath
               << ": unsupported mode=" << cstx.stx_mode << dendl;
@@ -1401,6 +1402,7 @@ int SyncMechanism::ll_remote_file_op() {
 int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
                                  DirRegistry *registry,
                                  std::shared_ptr<SnapSyncStat> &sync_stat,
+                                 LocalSyncStat* local_stat,
                                  const FHandles &fh) {
   bool need_data_sync = cur_entry->create_fresh() ||
                         cur_entry->purge_remote() ||
@@ -1463,9 +1465,11 @@ int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
     return r;
   }
   if (cur_entry->change_mask & all_change) {
-    sync_stat->current_stat.inc_file_attr_synced_count();
+    local_stat->inc_files_attr_synced_count(sync_stat->current_stat,
+                                            stat_flush_counter_gap);
   } else {
-    sync_stat->current_stat.inc_file_skipped_count();
+    local_stat->inc_files_skipped_count(sync_stat->current_stat,
+                                        stat_flush_counter_gap);
   }
   
   return 0;
@@ -1564,7 +1568,7 @@ int SyncMechanism::ll_cleanup_remote_entry() {
     SyncMechanism *syncm =
         new LL_DeleteMechanism(replayer->m_local_mount, std::move(d_entry),
                                registry, sync_stat, fh, replayer);
-    registry->sync_pool->sync_direct(syncm);
+    registry->sync_pool->sync_direct(syncm, local_stat);
   }
 
   r = ll_unlink_cur_dir_entry();
@@ -1581,6 +1585,7 @@ int PeerReplayer::cleanup_remote_entry(const std::string &epath,
                                        DirRegistry *registry,
                                        const FHandles &fh,
                                        std::shared_ptr<SnapSyncStat> &sync_stat,
+                                       LocalSyncStat* local_stat,
                                        int not_dir) {
   dout(20) << ": dir_root=" << registry->dir_root << ", epath=" << epath
            << dendl;
@@ -1601,7 +1606,8 @@ int PeerReplayer::cleanup_remote_entry(const std::string &epath,
       return r;
     }
     if (r == 0) {
-      sync_stat->current_stat.inc_file_del_count();
+      local_stat->inc_files_deleted_count(sync_stat->current_stat,
+                                          stat_flush_counter_gap);
       return r;
     }
   }
@@ -1633,7 +1639,8 @@ int PeerReplayer::cleanup_remote_entry(const std::string &epath,
       derr << ": failed to remove remote entry=" << epath << ": "
            << cpp_strerror(r) << dendl;
     }
-    sync_stat->current_stat.inc_file_del_count();
+    local_stat->inc_files_deleted_count(sync_stat->current_stat,
+                                        stat_flush_counter_gap);
     return r;
   }
 
@@ -1688,7 +1695,8 @@ int PeerReplayer::cleanup_remote_entry(const std::string &epath,
               << cpp_strerror(r) << dendl;
           break;
         }
-        sync_stat->current_stat.inc_dir_deleted_count();
+        local_stat->inc_dir_deleted_count(sync_stat->current_stat,
+                                          stat_flush_counter_gap);
 
         dout(10) << ": done for remote directory=" << entry.epath << dendl;
         if (entry.dirp && ceph_closedir(m_remote_mount, entry.dirp) < 0) {
@@ -1724,7 +1732,8 @@ int PeerReplayer::cleanup_remote_entry(const std::string &epath,
         break;
       }
       dout(10) << ": done for remote file=" << entry.epath << dendl;
-      sync_stat->current_stat.inc_file_del_count();
+      local_stat->inc_files_deleted_count(sync_stat->current_stat,
+                                          stat_flush_counter_gap);
       rm_stack.pop();
     }
   }
@@ -1868,7 +1877,7 @@ int SyncMechanism::ll_propagate_deleted_entries(int &cache_size) {
       SyncMechanism *syncm =
           new LL_DeleteMechanism(replayer->m_local_mount, std::move(d_entry),
                                  registry, sync_stat, fh, replayer);
-      registry->sync_pool->sync_anyway(syncm);
+      registry->sync_pool->sync_anyway(syncm, local_stat);
     } else if (extra_flags) {
       cur_entry->cache_map[d_name] =
           PeerReplayer::CacheInfo(std::move(p_inode), pstx);
@@ -1882,7 +1891,7 @@ int PeerReplayer::propagate_deleted_entries(
     const std::string &epath, DirRegistry *registry,
     std::shared_ptr<SnapSyncStat> &sync_stat, const FHandles &fh,
     std::unordered_map<std::string, unsigned int> &change_mask_map,
-    int &change_mask_map_size) {
+    int &change_mask_map_size, LocalSyncStat *local_stat) {
   dout(10) << ": dir_root=" << registry->dir_root << ", epath=" << epath
            << dendl;
   ceph_dir_result *dirp;
@@ -1972,7 +1981,7 @@ int PeerReplayer::propagate_deleted_entries(
       SyncMechanism *syncm = new DeleteMechanism(
           m_local_mount, std::move(std::make_shared<SyncEntry>(dpath)),
           registry, sync_stat, fh, this, !S_ISDIR(pstx.stx_mode));
-      registry->sync_pool->sync_anyway(syncm);
+      registry->sync_pool->sync_anyway(syncm, local_stat);
     } else if (extra_flags) {
       unsigned int change_mask = 0;
       build_change_mask(pstx, cstx, false, purge_remote, change_mask);
@@ -2272,9 +2281,11 @@ void PeerReplayer::DirSyncPool::run(DirScanner *dir_scanner) {
       });
       if (dir_scanner->stop_called) {
         dir_scanner->active = false;
+        dir_scanner->local_stat.flush(sync_stat->current_stat);
         break;
       }
       task = sync_queue.front();
+      task->local_stat = &dir_scanner->local_stat;
       sync_queue.pop();
       queued--;
     }
@@ -2304,14 +2315,17 @@ bool PeerReplayer::DirSyncPool::try_sync(SyncMechanism *task) {
   return success;
 }
 
-void PeerReplayer::DirSyncPool::sync_anyway(SyncMechanism *task) {
+void PeerReplayer::DirSyncPool::sync_anyway(
+    SyncMechanism *task, LocalSyncStat *local_stat) {
   if (!try_sync(task)) {
-    sync_direct(task);
+    sync_direct(task, local_stat);
   }
 }
 
-void PeerReplayer::DirSyncPool::sync_direct(SyncMechanism *task) {
+void PeerReplayer::DirSyncPool::sync_direct(
+    SyncMechanism *task, LocalSyncStat *local_stat) {
   task->sync_in_flight();
+  task->local_stat = local_stat;
   task->complete(low_level);
 }
 
@@ -2445,11 +2459,13 @@ int SyncMechanism::ll_update_remote_stat() {
     }
   }
   if (S_ISDIR(cstx.stx_mode)) {
-    sync_stat->current_stat.inc_dir_scanned_count();
+    local_stat->inc_dir_scanned_count(sync_stat->current_stat,
+                                      replayer->stat_flush_counter_gap);
   }
   if (mask == 0) {
     if (!S_ISDIR(cstx.stx_mode)) {
-      sync_stat->current_stat.inc_file_skipped_count();
+      local_stat->inc_files_skipped_count(sync_stat->current_stat,
+                                          replayer->stat_flush_counter_gap);
     }
     return 0;
   }
@@ -2474,9 +2490,11 @@ int SyncMechanism::ll_update_remote_stat() {
     return r;
   }
   if (!S_ISDIR(cur_entry->stx.stx_mode)) {
-    sync_stat->current_stat.inc_file_attr_synced_count();
+    local_stat->inc_files_attr_synced_count(sync_stat->current_stat,
+                                            replayer->stat_flush_counter_gap);
   } else {
-    sync_stat->current_stat.inc_dir_attr_synced_count();
+    local_stat->inc_dir_attr_synced_count(sync_stat->current_stat,
+                                          replayer->stat_flush_counter_gap);
   }
   // dout(0) << ": --->" << cur_entry->epath << dendl;
   return 0;
@@ -2645,7 +2663,7 @@ void DeleteMechanism::finish(int r) {
     goto notify_finish;
   }
   r = replayer->cleanup_remote_entry(cur_entry->epath, registry, fh, sync_stat,
-                                     not_dir);
+                                     local_stat, not_dir);
   if (r < 0 && r != -ENOENT) {
     derr << ": failed to cleanup remote entry=" << cur_entry->epath << ": "
          << cpp_strerror(r) << dendl;
@@ -2665,7 +2683,6 @@ void FileSyncMechanism::finish(int r) {
     registry->set_failed(x);
   }
 notify_finish:
-  sync_stat->current_stat.dec_file_in_flight_count();
   registry->dec_sync_indicator();
 }
 
@@ -2690,8 +2707,8 @@ int FileSyncMechanism::sync_file() {
     return r;
   }
   r = replayer->sync_attributes(cur_entry, fh);
-  sync_stat->current_stat.inc_file_data_synced_count(cur_entry->stx.stx_size);
-  sync_stat->current_stat.inc_file_attr_synced_count();
+  local_stat->inc_files_attr_synced_count(sync_stat->current_stat,
+                                          replayer->stat_flush_counter_gap);
   return r;
 }
 
@@ -2893,7 +2910,7 @@ int DirSnapDiffSync::ll_go_next() {
         SyncMechanism *syncm = new LL_DeleteMechanism(
             replayer->m_local_mount, std::move(deleted_entry), registry,
             sync_stat, fh, replayer);
-        registry->sync_pool->sync_anyway(syncm);
+        registry->sync_pool->sync_anyway(syncm, local_stat);
         entry->deleted_sibling_exist = false;
       }
     }
@@ -2989,7 +3006,7 @@ int DirSnapDiffSync::go_next() {
         SyncMechanism *syncm = new DeleteMechanism(
             m_local, std::move(deleted_entry), registry, sync_stat, fh,
             replayer, (DT_DIR != entry->deleted_sibling.dir_entry.d_type));
-        registry->sync_pool->sync_anyway(syncm);
+        registry->sync_pool->sync_anyway(syncm, local_stat);
         entry->deleted_sibling_exist = false;
       }
     }
@@ -3082,7 +3099,7 @@ int DirSnapDiffSync::ll_sync_current_entry() {
     syncm = new DirBruteDiffSync(
         replayer->m_local_mount, std::move(cur_entry), registry, sync_stat,
         failed_prev ? registry->remotediff_fh : fh, replayer);
-    registry->sync_pool->sync_direct(syncm);
+    registry->sync_pool->sync_direct(syncm, local_stat);
     cur_entry = nullptr;
     return 0;
   }
@@ -3186,18 +3203,20 @@ int DirSnapDiffSync::sync_current_entry() {
     syncm = new DirBruteDiffSync(
         m_local, std::move(cur_entry), registry, sync_stat,
         failed_prev ? registry->remotediff_fh : fh, replayer);
-    registry->sync_pool->sync_direct(syncm);
+    registry->sync_pool->sync_direct(syncm, local_stat);
     return 0;
   }
 
   if (S_ISDIR(cur_entry->stx.stx_mode)) { // is a directory
-    r = replayer->remote_mkdir(cur_entry, fh, sync_stat);
+    r = replayer->remote_mkdir(cur_entry, fh, sync_stat, local_stat);
     if (r < 0) {
       return r;
     }
-    sync_stat->current_stat.inc_dir_scanned_count();
+    local_stat->inc_dir_scanned_count(sync_stat->current_stat,
+                                      replayer->stat_flush_counter_gap);
   } else {
-    r = replayer->remote_file_op(cur_entry, registry, sync_stat, fh);
+    r = replayer->remote_file_op(cur_entry, registry, sync_stat, local_stat,
+                                 fh);
     cur_entry = nullptr;
     return r;
   }
@@ -3311,7 +3330,8 @@ int DirBruteDiffSync::ll_go_next() {
             (S_ISDIR(d_entry->pstx.stx_mode) ? DT_DIR : DT_REG);
         entry->cache_map.erase(it);
         cache_size--;
-        sync_stat->current_stat.inc_cache_hit();
+        local_stat->inc_cache_hit(sync_stat->current_stat,
+                                  replayer->stat_flush_counter_gap);
       }
     } else {
       d_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
@@ -3391,7 +3411,8 @@ int DirBruteDiffSync::go_next() {
         // insert more entry
         par_change_mask_map.erase(it);
         change_mask_map_size--;
-        sync_stat->current_stat.inc_cache_hit();
+        local_stat->inc_cache_hit(sync_stat->current_stat,
+                                  replayer->stat_flush_counter_gap);
       }
     } else {
       change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
@@ -3462,7 +3483,7 @@ int DirBruteDiffSync::ll_sync_current_entry() {
     SyncMechanism *syncm = new DirBruteDiffSync(
         replayer->m_local_mount, std::move(cur_entry), registry, sync_stat,
         registry->remotediff_fh, replayer);
-    registry->sync_pool->sync_direct(syncm);
+    registry->sync_pool->sync_direct(syncm, local_stat);
     cur_entry = nullptr;
     return 0;
   }
@@ -3470,7 +3491,7 @@ int DirBruteDiffSync::ll_sync_current_entry() {
   if (cur_entry->purge_remote()) {
     SyncMechanism *syncm = new LL_DeleteMechanism(
         replayer->m_local_mount, cur_entry, registry, sync_stat, fh, replayer);
-    registry->sync_pool->sync_direct(syncm);
+    registry->sync_pool->sync_direct(syncm, local_stat);
     cur_entry->change_mask |= PeerReplayer::SyncEntry::CREATE_FRESH;
   }
 
@@ -3555,13 +3576,13 @@ int DirBruteDiffSync::sync_current_entry() {
     SyncMechanism *syncm =
         new DirBruteDiffSync(m_local, std::move(cur_entry), registry, sync_stat,
                              registry->remotediff_fh, replayer);
-    registry->sync_pool->sync_direct(syncm);
+    registry->sync_pool->sync_direct(syncm, local_stat);
     return 0;
   }
 
   if (cur_entry->purge_remote()) {
     rem_r = replayer->cleanup_remote_entry(
-        cur_entry->epath, registry, fh, sync_stat,
+        cur_entry->epath, registry, fh, sync_stat, local_stat,
         cur_entry->wasnt_dir_in_prev_snapshot());
     if (rem_r < 0 && rem_r != -ENOENT) {
       derr << ": failed to cleanup remote entry=" << cur_entry->epath << ": "
@@ -3571,13 +3592,15 @@ int DirBruteDiffSync::sync_current_entry() {
     }
   }
   if (S_ISDIR(cur_entry->stx.stx_mode)) {
-    r = replayer->remote_mkdir(cur_entry, fh, sync_stat);
+    r = replayer->remote_mkdir(cur_entry, fh, sync_stat, local_stat);
     if (r < 0) {
       return r;
     }
-    sync_stat->current_stat.inc_dir_scanned_count();
+    local_stat->inc_dir_scanned_count(sync_stat->current_stat,
+                                      replayer->stat_flush_counter_gap);
   } else {
-    r = replayer->remote_file_op(cur_entry, registry, sync_stat, fh);
+    r = replayer->remote_file_op(cur_entry, registry, sync_stat, local_stat,
+                                 fh);
     cur_entry = nullptr;
     return r;
   }
@@ -3599,7 +3622,7 @@ int DirBruteDiffSync::sync_current_entry() {
   if (!cur_entry->create_fresh() && !cur_entry->purge_remote()) {
     r = replayer->propagate_deleted_entries(cur_entry->epath, registry,
                                             sync_stat, fh, change_mask_map,
-                                            change_mask_map_size);
+                                            change_mask_map_size, local_stat);
     if (r < 0 && r != -ENOENT) {
       derr << ": failed to propagate missing dirs: " << cpp_strerror(r)
            << dendl;
@@ -3697,6 +3720,7 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
       << ", cephfs_mirror_skip_error=" << skip_error
       << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
       << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
+      << ", cephfs_mirror_stat_flush_counter_gap=" << stat_flush_counter_gap
       << dendl;
   // ceph_assert(sync_flags == AT_SYMLINK_NOFOLLOW);
   // sync_flags = AT_SYMLINK_NOFOLLOW;
@@ -3729,12 +3753,12 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
   uint64_t rfiles = 0, rbytes = 0;
   get_r_stats(cur_snap_path, rfiles, rbytes);
   lock.lock();
-  registry->sync_start(file_mirror_pool.sync_start(dir_root, true));
+  registry->sync_start(file_mirror_pool.sync_start(dir_root, sync_stat, true));
   sync_stat->current_stat.rfiles = rfiles;
   sync_stat->current_stat.rbytes = rbytes;
   sync_stat->current_stat.start_timer();
-  registry->sync_pool =
-      std::make_unique<DirSyncPool>(dir_scanning_thread, dir_root, m_peer);
+  registry->sync_pool = std::make_unique<DirSyncPool>(
+      dir_scanning_thread, dir_root, m_peer, sync_stat);
   registry->sync_pool->set_low_level(true);
   registry->sync_pool->activate();
   lock.unlock();
@@ -3774,7 +3798,8 @@ int PeerReplayer::ll_do_synchronize(const std::string &dir_root,
     syncm = new DirBruteDiffSync(m_local_mount, std::move(cur_entry), registry,
                                  sync_stat, registry->remotediff_fh, this);
   }
-  registry->sync_pool->sync_anyway(syncm);
+  LocalSyncStat local_stat;
+  registry->sync_pool->sync_anyway(syncm, &local_stat);
   registry->wait_for_sync_finish();
 
   should_backoff(registry, &r);
@@ -3825,6 +3850,7 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       << ", cephfs_mirror_skip_error=" << skip_error
       << ", cephfs_mirror_use_low_level_api=" << use_low_level_api
       << ", cephfs_mirror_use_at_statx_dont_sync=" << use_at_statx_dont_sync
+      << ", cephfs_mirror_stat_flush_counter_gap=" << stat_flush_counter_gap
       << dendl;
 
   dout(0) << ": sync start-->" << dir_root << ",cur_snap= " << current.first
@@ -3914,12 +3940,12 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
   lock.lock();
   dout(0) << ": Number of dir scanning threads=" << dir_scanning_thread
           << dendl;
-  registry->sync_start(file_mirror_pool.sync_start(dir_root));
+  registry->sync_start(file_mirror_pool.sync_start(dir_root, sync_stat));
   sync_stat->current_stat.rfiles = std::stoull(rfiles);
   sync_stat->current_stat.rbytes = std::stoull(rbytes);
   sync_stat->current_stat.start_timer();
-  registry->sync_pool =
-      std::make_unique<DirSyncPool>(dir_scanning_thread, dir_root, m_peer);
+  registry->sync_pool = std::make_unique<DirSyncPool>(
+      dir_scanning_thread, dir_root, m_peer, sync_stat);
   registry->sync_pool->activate();
   lock.unlock();
 
@@ -3961,7 +3987,8 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
     syncm = new DirBruteDiffSync(m_local_mount, std::move(cur_entry), registry,
                                  sync_stat, registry->remotediff_fh, this);
   }
-  registry->sync_pool->sync_anyway(syncm);
+  LocalSyncStat local_stat;
+  registry->sync_pool->sync_anyway(syncm, &local_stat);
   registry->wait_for_sync_finish();
   if (!prev || registry->snapdiff_fh.p_fd < 0 || !use_snapdiff_api) {
     if (root_entry->dirp &&
@@ -4478,6 +4505,10 @@ void PeerReplayer::run_scan() {
       m_cond.wait_for(locker, timeout,
                       [this] { return is_stopping(); });
     }
+    if (is_stopping()) {
+      dout(5) << ": exiting" << dendl;
+      break;
+    }
 
     if (!(start_syncing && nr_replayers > 0 &&
           m_directories.size() > m_registered.size() &&
@@ -4495,6 +4526,9 @@ void PeerReplayer::run_scan() {
 
     locker.lock();
 
+    // dout(0) << "start idx=" << idx << ", next_dir=" << next_dir
+    //         << ", registered=" << m_registered.size()
+    //         << ", total=" << m_directories.size() << dendl;
     if (idx >= m_directories.size() || m_directories[idx] != next_dir) {
       idx = std::find(m_directories.begin(), m_directories.end(), next_dir) -
             m_directories.begin();
@@ -4507,6 +4541,9 @@ void PeerReplayer::run_scan() {
                     m_directories.size() > m_registered.size();
          ++i, idx = (idx + 1) % m_directories.size()) {
       next_dir = m_directories[idx];
+      // dout(0) << "idx=" << idx << ", next_dir=" << next_dir
+      //         << ", registered=" << m_registered.size()
+      //         << ", total=" << m_directories.size() << dendl;
       auto &sync_stat = m_snap_sync_stats.at(next_dir);
       if (sync_stat->failed) {
         std::chrono::duration<double> d =

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -603,7 +603,9 @@ void PeerReplayer::shutdown() {
     }
     dout(0) << ": All threads joined" << dendl;
   }
+  locker.lock();
   m_cond.notify_all();
+  locker.unlock();
 
   scanner_thread->join();
   dout(0) << ": scanner threads joined" << dendl;
@@ -3125,10 +3127,12 @@ int DirSnapDiffSync::ll_sync_current_entry() {
     cur_entry = nullptr;
     return 0;
   }
-
-  r = ceph_open_snapdiff(replayer->m_local_mount, registry->dir_root.c_str(),
-                         cur_entry->epath.c_str(), (*fh.m_prev).first.c_str(),
-                         fh.m_current.first.c_str(), &cur_entry->info);
+  ceph_assert(cur_entry->fh.ll_info.p_inode != nullptr);
+  ceph_assert(cur_entry->fh.ll_info.c_inode != nullptr);
+  r = ceph_ll_open_snapdiff(replayer->m_local_mount,
+                            cur_entry->fh.ll_info.p_inode.get(),
+                            cur_entry->fh.ll_info.c_inode.get(),
+                            &cur_entry->info, replayer->m_local_perms);
 
   if (r != 0) {
     derr << ": failed to do low level openning of snapdiff between diff base's "

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1202,7 +1202,7 @@ int FileSyncMechanism::ll_copy_to_remote() {
          << cpp_strerror(r) << dendl;
     goto free_ptr;
   }
-  // if (fh.p_mnt == replayer->m_remote_mount) {
+  // if (fh.p_mnt == replayer->m_local_mount && fh.m_current.first == "snap_9") {
   //   dout(0) << ": --->" << cur_entry->epath
   //          << ", p_inode=" << cur_entry->fh.ll_info.p_info.inode
   //          << ", c_inode=" << cur_entry->fh.ll_info.c_info.inode
@@ -3379,6 +3379,22 @@ int DirSnapDiffSync::ll_sync_current_entry() {
     return 0;
   }
 
+  // if (fh.p_mnt == replayer->m_local_mount && fh.m_current.first == "snap_9") {
+  //   dout(0) << ": --->" << cur_entry->epath
+  //          << ", p_inode=" << cur_entry->fh.ll_info.p_info.inode
+  //          << ", c_inode=" << cur_entry->fh.ll_info.c_info.inode
+  //          << ", r_inode=" << cur_entry->fh.ll_info.r_info.inode
+  //          << ", S_ISDIR(cur_entry->stx.stx_mode)=" << S_ISDIR(cur_entry->stx.stx_mode)
+  //          << ", create_fresh=" << cur_entry->create_fresh()
+  //          << ", purge_remote=" << cur_entry->purge_remote()
+  //          << ", cur_entry->stx.stx_mtime=" << cur_entry->stx.stx_mtime
+  //          << ", cur_entry->pstx.stx_mtime=" << cur_entry->pstx.stx_mtime
+  //          << ", cur_entry->stx.stx_size=" << cur_entry->stx.stx_size
+  //          << ", cur_entry->pstx.stx_size=" << cur_entry->pstx.stx_size
+  //          << ", need_data_sync=" << need_data_sync
+  //          << dendl;
+  // }
+
   if (S_ISDIR(cur_entry->stx.stx_mode)) {
     r = ll_update_remote_stat();
     if (r < 0) {
@@ -3767,7 +3783,7 @@ int DirBruteDiffSync::ll_sync_current_entry() {
   }
 
   ll_populate_remote_inode_with_diff_base();
-  // if (fh.p_mnt == replayer->m_remote_mount) {
+  // if (fh.p_mnt == replayer->m_local_mount && fh.m_current.first == "snap_9") {
   //   dout(0) << ": --->" << cur_entry->epath
   //          << ", p_inode=" << cur_entry->fh.ll_info.p_info.inode
   //          << ", c_inode=" << cur_entry->fh.ll_info.c_info.inode

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -518,6 +518,7 @@ private:
     bool pstat_known = false;
     DirUniquePtr udirp = nullptr;
     std::unordered_map<std::string, PeerReplayer::CacheInfo> cache_map;
+    std::unordered_map<std::string, std::pair<int, int>> snapdiff_map;
     int prev_d_type = -1;
     // ll_info
 
@@ -1006,7 +1007,6 @@ private:
   virtual int ll_go_next() = 0;
   virtual int sync_current_entry() = 0;
   virtual int ll_sync_current_entry() = 0;
-  virtual void ll_finish_sync() = 0;
 };
 
 class DirBruteDiffSync : public DirSyncMechanism {
@@ -1029,7 +1029,6 @@ private:
   int ll_go_next() override;
   int sync_current_entry() override;
   int ll_sync_current_entry() override;
-  void ll_finish_sync() override {}
 };
 
 class DirSnapDiffSync : public DirSyncMechanism {
@@ -1049,7 +1048,6 @@ private:
   int sync_current_entry() override;
   int ll_sync_current_entry() override;
   bool should_delete_current_entry(int not_dir = -1);
-  void ll_finish_sync() override;
 };
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -51,13 +51,15 @@ struct SnapSyncStat {
     uint64_t rbytes;
     std::string diff_base = "";
     std::atomic<uint64_t> files_in_flight{0};
-    std::atomic<uint64_t> files_synced{0};
+    std::atomic<uint64_t> files_data_synced{0};
+    std::atomic<uint64_t> files_attr_synced{0};
     std::atomic<uint64_t> files_deleted{0};
     std::atomic<uint64_t> files_skipped{0};
     std::atomic<uint64_t> file_bytes_synced{0};
     std::atomic<uint64_t> dir_created{0};
     std::atomic<uint64_t> dir_deleted{0};
     std::atomic<uint64_t> dir_scanned{0};
+    std::atomic<uint64_t> dir_attr_synced{0};
     std::atomic<uint64_t> cache_hit{0};
     boost::optional<monotime> start_time;
     SyncStat() : start_time(boost::none) {}
@@ -65,13 +67,15 @@ struct SnapSyncStat {
         : rfiles(other.rfiles), rbytes(other.rbytes),
           diff_base(other.diff_base),
           files_in_flight(other.files_in_flight.load()),
-          files_synced(other.files_synced.load()),
+          files_data_synced(other.files_data_synced.load()),
+          files_attr_synced(other.files_attr_synced.load()),
           files_deleted(other.files_deleted.load()),
           files_skipped(other.files_skipped.load()),
           file_bytes_synced(other.file_bytes_synced.load()),
           dir_created(other.dir_created.load()),
           dir_deleted(other.dir_deleted.load()),
           dir_scanned(other.dir_scanned.load()),
+          dir_attr_synced(other.dir_attr_synced.load()),
           cache_hit(other.cache_hit.load()) {}
     SyncStat &operator=(const SyncStat &other) {
       if (this != &other) { // Self-assignment check
@@ -79,48 +83,82 @@ struct SnapSyncStat {
         rbytes = other.rbytes;
         diff_base = other.diff_base;
         files_in_flight.store(other.files_in_flight.load());
-        files_synced.store(other.files_synced.load());
+        files_data_synced.store(other.files_data_synced.load());
+        files_attr_synced.store(other.files_attr_synced.load());
         files_deleted.store(other.files_deleted.load());
         files_skipped.store(other.files_skipped.load());
         file_bytes_synced.store(other.file_bytes_synced.load());
         dir_created.store(other.dir_created.load());
         dir_deleted.store(other.dir_deleted.load());
         dir_scanned.store(other.dir_scanned.load());
+        dir_attr_synced.store(other.dir_attr_synced.load());
         cache_hit.store(other.cache_hit.load());
       }
       return *this;
     }
-    inline void inc_cache_hit() { cache_hit++; }
-    inline void inc_file_del_count() { files_deleted++; }
-    inline void inc_file_skipped_count() { files_skipped++; }
-    inline void inc_files_synced(bool data_synced, uint64_t file_size) {
-      files_synced++;
-      if (data_synced) {
-        file_bytes_synced += file_size;
-      }
+    inline void inc_cache_hit() {
+      cache_hit.fetch_add(1, std::memory_order_relaxed);
+    }
+    inline void inc_file_del_count() {
+      files_deleted.fetch_add(1, std::memory_order_relaxed);
+    }
+    inline void inc_file_skipped_count() {
+      files_skipped.fetch_add(1, std::memory_order_relaxed);
+    }
+    inline void inc_file_data_synced_count(uint64_t file_size) {
+      files_data_synced.fetch_add(1, std::memory_order_relaxed);
+      file_bytes_synced.fetch_add(file_size, std::memory_order_relaxed);
+    }
+    inline void inc_file_attr_synced_count() {
+      files_attr_synced.fetch_add(1, std::memory_order_relaxed);
     }
     inline void set_diff_base(const std::string &_diff_base) {
       diff_base = _diff_base;
     }
-    inline void inc_file_in_flight_count() { files_in_flight++; }
-    inline void dec_file_in_flight_count() { files_in_flight--; }
-    inline void inc_dir_created_count() { dir_created++; }
-    inline void inc_dir_deleted_count() { dir_deleted++; }
-    inline void inc_dir_scanned_count() { dir_scanned++; }
+    inline void inc_file_in_flight_count() {
+      files_in_flight.fetch_add(1, std::memory_order_relaxed);
+    }
+    inline void dec_file_in_flight_count() {
+      files_in_flight.fetch_sub(1, std::memory_order_relaxed);
+    }
+    inline void inc_dir_created_count() {
+      dir_created.fetch_add(1, std::memory_order_relaxed);
+    }
+    inline void inc_dir_deleted_count() {
+      dir_deleted.fetch_add(1, std::memory_order_relaxed);
+    }
+    inline void inc_dir_scanned_count() {
+      dir_scanned.fetch_add(1, std::memory_order_relaxed);
+    }
+    inline void inc_dir_attr_synced_count() {
+      dir_attr_synced.fetch_add(1, std::memory_order_relaxed);
+    }
     inline void start_timer() { start_time = clock::now(); }
     void dump(Formatter *f) {
       f->dump_unsigned("rfiles", rfiles);
       f->dump_unsigned("rbytes", rbytes);
       f->dump_string("diff_base", diff_base);
-      f->dump_unsigned("files_in_flight", files_in_flight.load());
-      f->dump_unsigned("files_synced", files_synced.load());
-      f->dump_unsigned("files_deleted", files_deleted.load());
-      f->dump_unsigned("files_skipped", files_skipped.load());
-      f->dump_unsigned("files_bytes_synced", file_bytes_synced.load());
-      f->dump_unsigned("dir_created", dir_created);
-      f->dump_unsigned("dir_scanned", dir_scanned);
-      f->dump_unsigned("dir_deleted", dir_deleted);
-      f->dump_unsigned("cache_hit", cache_hit);
+      f->dump_unsigned("files_in_flight",
+                       files_in_flight.load(std::memory_order_relaxed));
+      f->dump_unsigned("files_data_synced",
+                       files_data_synced.load(std::memory_order_relaxed));
+      f->dump_unsigned("files_attr_synced",
+                       files_attr_synced.load(std::memory_order_relaxed));
+      f->dump_unsigned("files_deleted",
+                       files_deleted.load(std::memory_order_relaxed));
+      f->dump_unsigned("files_skipped",
+                       files_skipped.load(std::memory_order_relaxed));
+      f->dump_unsigned("files_bytes_synced",
+                       file_bytes_synced.load(std::memory_order_relaxed));
+      f->dump_unsigned("dir_created",
+                       dir_created.load(std::memory_order_relaxed));
+      f->dump_unsigned("dir_scanned",
+                       dir_scanned.load(std::memory_order_relaxed));
+      f->dump_unsigned("dir_deleted",
+                       dir_deleted.load(std::memory_order_relaxed));
+      f->dump_unsigned("dir_attr_synced",
+                       dir_attr_synced.load(std::memory_order_relaxed));
+      f->dump_unsigned("cache_hit", cache_hit.load(std::memory_order_relaxed));
       if (start_time) {
         std::chrono::duration<double> duration = clock::now() - *start_time;
         double time_elapsed = duration.count();
@@ -128,7 +166,8 @@ struct SnapSyncStat {
         double speed = 0;
         std::string syncing_speed = "";
         if (time_elapsed > 0) {
-          speed = (file_bytes_synced * 8.0) / time_elapsed;
+          speed = (file_bytes_synced.load(std::memory_order_relaxed) * 8.0) /
+                  time_elapsed;
           if (speed >= (double)1e9) {
             syncing_speed = std::to_string(speed / (double)1e9) + "Gbps";
           } else if (speed >= (double)1e6) {
@@ -190,6 +229,7 @@ struct SnapSyncStat {
 
 class SyncMechanism;
 class DeleteMechanism;
+class LL_DeleteMechanism;
 class FileSyncMechanism;
 class DirSyncMechanism;
 class DirBruteDiffSync;
@@ -226,6 +266,7 @@ public:
   void reopen_logs();
   friend class SyncMechanism;
   friend class DeleteMechanism;
+  friend class LL_DeleteMechanism;
   friend class FileSyncMechanism;
   friend class DirSyncMechanism;
   friend class DirBruteDiffSync;
@@ -238,7 +279,7 @@ private:
   inline static const std::string SERVICE_DAEMON_RECOVERED_DIR_COUNT_KEY = "recovery_count";
 
   bool start_syncing = false;
-  bool use_snapdiff_api = false;
+  bool use_snapdiff_api = true;
   bool lock_directory_before_sync = false;
   uint64_t remote_timeout = 0;
   uint64_t local_timeout = 0;
@@ -248,7 +289,10 @@ private:
   uint64_t thread_pool_queue_size = 5000;
   uint64_t max_element_in_cache_per_thread = 1000000;
   uint64_t max_consecutive_failures_before_remote_sync = 2;
-  bool skip_error = true;
+  bool skip_error = false;
+  bool use_low_level_api = true;
+  bool use_at_statx_dont_sync = true;
+  unsigned int sync_flags = AT_SYMLINK_NOFOLLOW | AT_STATX_DONT_SYNC;
 
       // file descriptor "triplet" for synchronizing a snapshot
   // w/ an added MountRef for accessing "previous" snapshot.
@@ -256,6 +300,13 @@ private:
   using SnapshotPair = std::pair<Snapshot, Snapshot>;
   class DirSyncPool;
   struct FHandles {
+    struct LL_Fhandle_Info {
+      InodeSharedPtr c_parent_inode = nullptr, c_inode = nullptr;
+      InodeSharedPtr p_parent_inode = nullptr, p_inode = nullptr;
+      InodeSharedPtr r_parent_inode = nullptr, r_inode = nullptr;
+      std::string c_path = "", p_path = "", r_path = "";
+      UserPermRef p_perms;
+    }ll_info;
     // open file descriptor on the snap directory for snapshot
     // currently being synchronized. Always use this fd with
     // @m_local_mount.
@@ -290,7 +341,7 @@ private:
     std::unique_ptr<DirSyncPool> sync_pool = nullptr;
     void set_failed(int r) {
       ceph_assert(r < 0);
-      if (failed) {
+      if (failed || canceled) {
         return;
       }
       failed.store(true);
@@ -312,7 +363,24 @@ private:
     }
   };
 
+  struct CacheInfo {
+    InodeSharedPtr p_inode = nullptr;
+    struct ceph_statx pstx;
+    CacheInfo() {}
+    CacheInfo(InodeSharedPtr &&p_inode, const struct ceph_statx &pstx)
+        : p_inode(std::move(p_inode)), pstx(pstx) {}
+  };
+
   struct SyncEntry {
+    // ll_info
+    FHandles fh;
+    struct ceph_statx pstx;
+    bool pstat_known = false;
+    DirUniquePtr udirp = nullptr;
+    std::unordered_map<std::string, PeerReplayer::CacheInfo> cache_map;
+    int prev_d_type = -1;
+    // ll_info
+
     static const unsigned int PURGE_REMOTE = (1 << 20);
     static const unsigned int CREATE_FRESH = (1 << 21);
     static const unsigned int WASNT_DIR_IN_PREV_SNAPSHOT = (1 << 22);
@@ -334,9 +402,14 @@ private:
 
     SyncEntry() {}
 
-    SyncEntry(std::string_view path) : epath(path) {}
+    SyncEntry(const std::string& path) : epath(path) {}
 
-    SyncEntry(std::string_view path, const struct ceph_statx &stx)
+    SyncEntry(std::string &&path) : epath(std::move(path)) {}
+
+    SyncEntry(std::string &&path, const struct ceph_statx &stx)
+        : epath(std::move(path)), stx(stx) {}
+
+    SyncEntry(const std::string &path, const struct ceph_statx &stx)
         : epath(path), stx(stx) {}
     SyncEntry(std::string_view path, ceph_dir_result *dirp,
               const struct ceph_statx &stx)
@@ -374,6 +447,8 @@ private:
     bool wasnt_dir_in_prev_snapshot() {
       return (change_mask & WASNT_DIR_IN_PREV_SNAPSHOT);
     }
+
+    void rollout(FHandles &parent_fh, const std::string &ename);
   };
 
   class DirSyncPool {
@@ -392,6 +467,8 @@ private:
       f->dump_unsigned("dir_sync_queue_size", sync_queue.size());
     }
     void update_qlimit(int _qlimit);
+    void set_low_level(bool _low_level) { low_level = _low_level; }
+    bool get_low_level() { return low_level; }
     friend class PeerReplayer;
 
   private:
@@ -418,6 +495,7 @@ private:
     int qlimit;
     std::string epath;
     const Peer &m_peer; // just for using dout
+    bool low_level = false;
   };
 
   bool is_stopping() {
@@ -503,10 +581,13 @@ private:
   Filesystem m_filesystem;
   Peer m_peer;
   // probably need to be encapsulated when supporting cancelations
+  InodeSharedPtr local_root_inode = nullptr, remote_root_inode = nullptr; 
   std::map<std::string, DirRegistry*> m_registered;
   std::vector<std::string> m_directories, m_deleted_directories;
   std::map<std::string, std::shared_ptr<SnapSyncStat>> m_snap_sync_stats;
   MountRef m_local_mount;
+  UserPermRef m_local_perms, m_remote_perms;
+  InodeSharedPtr m_local_root_inode = nullptr, m_remote_root_inode = nullptr;
   ServiceDaemon *m_service_daemon;
   PeerReplayerAdminSocketHook *m_asok_hook = nullptr;
 
@@ -538,7 +619,7 @@ private:
       const std::string &dir_root,
       const std::map<uint64_t, std::pair<std::string, std::string>> &snaps);
   int propagate_deleted_entries(
-      const std::string &epath, DirRegistry *registry,
+      const  std::string &epath, DirRegistry *registry,
       std::shared_ptr<SnapSyncStat> &sync_stat, const FHandles &fh,
       std::unordered_map<std::string, unsigned int> &change_mask_map,
       int &change_mask_map_size);
@@ -550,6 +631,13 @@ private:
   int should_sync_entry(const std::string &epath, const struct ceph_statx &cstx,
                         const FHandles &fh, bool *need_data_sync, bool *need_attr_sync);
 
+  int ll_open_inode(MountRef mnt, InodeSharedPtr &parent_inode,
+                    const std::string &dir_path, InodeSharedPtr &inode_shared,
+                    struct ceph_statx &stx, unsigned int want,
+                    UserPermRef perms);
+  int ll_open_dirp(MountRef mnt, InodeSharedPtr &inode, DirUniquePtr &udirp,
+                   UserPermRef perms);
+
   int open_dir(MountRef mnt, const std::string &dir_path, boost::optional<uint64_t> snap_id);
   int pre_sync_check_and_open_handles(const std::string &dir_root,
                                       const Snapshot &current,
@@ -557,10 +645,22 @@ private:
                                       FHandles *snapdiff_fh,
                                       FHandles *remotediff_fh);
 
+  int ll_pre_sync_check_and_open_registry_inodes(const std::string &dir_root,
+                                                 const Snapshot &current,
+                                                 boost::optional<Snapshot> prev,
+                                                 DirRegistry *registry);
+
   int do_synchronize(const std::string &dir_root, const Snapshot &current,
                      boost::optional<Snapshot> prev);
   int do_synchronize(const std::string &dir_root, const Snapshot &current) {
     return do_synchronize(dir_root, current, boost::none);
+  }
+  int get_r_stats(const std::string &dir_path, uint64_t &rfiles,
+                  uint64_t &rbytes);
+  int ll_do_synchronize(const std::string &dir_root, const Snapshot &current,
+                        boost::optional<Snapshot> prev);
+  int ll_do_synchronize(const std::string &dir_root, const Snapshot &current) {
+    return ll_do_synchronize(dir_root, current, boost::none);
   }
 
   int synchronize(const std::string &dir_root, const Snapshot &current,
@@ -613,14 +713,19 @@ public:
       : m_local(m_local), m_peer(replayer->m_peer),
         cur_entry(std::move(cur_entry)), registry(registry),
         sync_stat(sync_stat), fh(fh), replayer(replayer) {}
+  SyncMechanism(MountRef m_local,
+                const std::shared_ptr<PeerReplayer::SyncEntry> &cur_entry,
+                PeerReplayer::DirRegistry *registry,
+                std::shared_ptr<SnapSyncStat> &sync_stat,
+                const PeerReplayer::FHandles &fh, PeerReplayer *replayer)
+      : m_local(m_local), m_peer(replayer->m_peer), cur_entry(cur_entry),
+        registry(registry), sync_stat(sync_stat), fh(fh), replayer(replayer) {}
 
   void sync_in_flight() { registry->inc_sync_indicator(); }
   bool sync_failed_or_canceled() {
     return (registry->failed || registry->canceled);
   }
-  std::shared_ptr<PeerReplayer::SyncEntry> &&move_cur_entry() {
-    return std::move(cur_entry);
-  }
+  friend class DirSyncMechanism;
 
 protected:
   MountRef m_local;
@@ -632,6 +737,17 @@ protected:
   PeerReplayer *replayer;
   int populate_change_mask(const PeerReplayer::FHandles &fh);
   int populate_current_stat(const PeerReplayer::FHandles &fh);
+  int ll_populate_cur_stat_and_cur_inode();
+  int ll_populate_prev_stat_and_prev_inode();
+  int ll_update_remote_stat();
+  int ll_populate_remote_inode();
+  bool ll_populate_remote_inode_with_diff_base();
+  int ll_remote_file_op();
+  int ll_unlink_cur_file_entry();
+  int ll_unlink_cur_dir_entry();
+  int ll_cleanup_remote_entry();
+  int ll_remote_mkdir();
+  int ll_propagate_deleted_entries(int &cache_size);
 };
 
 class DeleteMechanism : public SyncMechanism {
@@ -649,6 +765,26 @@ public:
 private:
   void finish(int r) override;
   int not_dir = -1;
+};
+
+class LL_DeleteMechanism : public SyncMechanism {
+public:
+  LL_DeleteMechanism(MountRef m_local,
+                     std::shared_ptr<PeerReplayer::SyncEntry> &&cur_entry,
+                     PeerReplayer::DirRegistry *registry,
+                     std::shared_ptr<SnapSyncStat> &sync_stat,
+                     const PeerReplayer::FHandles &fh, PeerReplayer *replayer)
+      : SyncMechanism(m_local, std::move(cur_entry), registry, sync_stat, fh,
+                      replayer) {}
+  LL_DeleteMechanism(MountRef m_local,
+                     const std::shared_ptr<PeerReplayer::SyncEntry> &cur_entry,
+                     PeerReplayer::DirRegistry *registry,
+                     std::shared_ptr<SnapSyncStat> &sync_stat,
+                     const PeerReplayer::FHandles &fh, PeerReplayer *replayer)
+      : SyncMechanism(m_local, cur_entry, registry, sync_stat, fh, replayer) {}
+
+private:
+  void finish(int r) override;
 };
 
 class FileSyncMechanism : public SyncMechanism {
@@ -674,6 +810,8 @@ public:
 private:
   void finish(int r) override;
   int sync_file();
+  int ll_sync_file();
+  int ll_copy_to_remote();
   FileMirrorPool::FileWorker* file_worker;
 };
 
@@ -690,13 +828,17 @@ public:
 protected:
   void finish(int r) override;
   int sync_tree();
+  int ll_sync_tree();
   bool try_spawning(SyncMechanism *syncm);
   std::stack<std::shared_ptr<PeerReplayer::SyncEntry>> m_sync_stack;
 
 private:
   virtual void finish_sync() = 0;
   virtual int go_next() = 0;
+  virtual int ll_go_next() = 0;
   virtual int sync_current_entry() = 0;
+  virtual int ll_sync_current_entry() = 0;
+  virtual void ll_finish_sync() = 0;
 };
 
 class DirBruteDiffSync : public DirSyncMechanism {
@@ -713,9 +855,13 @@ private:
   std::stack<std::unordered_map<std::string, unsigned int>>
       m_change_mask_map_stack;
   int change_mask_map_size = 0;
+  int cache_size = 0;
   void finish_sync() override;
   int go_next() override;
+  int ll_go_next() override;
   int sync_current_entry() override;
+  int ll_sync_current_entry() override;
+  void ll_finish_sync() override {}
 };
 
 class DirSnapDiffSync : public DirSyncMechanism {
@@ -731,8 +877,11 @@ public:
 private:
   void finish_sync() override;
   int go_next() override;
+  int ll_go_next() override;
   int sync_current_entry() override;
+  int ll_sync_current_entry() override;
   bool should_delete_current_entry(int not_dir = -1);
+  void ll_finish_sync() override;
 };
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -301,9 +301,12 @@ private:
   class DirSyncPool;
   struct FHandles {
     struct LL_Fhandle_Info {
-      InodeSharedPtr c_parent_inode = nullptr, c_inode = nullptr;
-      InodeSharedPtr p_parent_inode = nullptr, p_inode = nullptr;
-      InodeSharedPtr r_parent_inode = nullptr, r_inode = nullptr;
+      std::vector<InodeSharedPtr> c_parent_inode = {nullptr};
+      InodeSharedPtr c_inode = nullptr;
+      std::vector<InodeSharedPtr> p_parent_inode = {nullptr};
+      InodeSharedPtr p_inode = nullptr;
+      std::vector<InodeSharedPtr> r_parent_inode = {nullptr};
+      InodeSharedPtr r_inode = nullptr;
       std::string c_path = "", p_path = "", r_path = "";
       UserPermRef p_perms;
     }ll_info;

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -417,6 +417,10 @@ private:
   bool turn_off_assert = false;
   std::string snap_prefix = "";
   bool sync_from_remote = false;
+  bool enable_local_batching = true;
+  uint64_t local_batch_size = 10000;
+  bool reset_inode_before_submission = false;
+
       // file descriptor "triplet" for synchronizing a snapshot
   // w/ an added MountRef for accessing "previous" snapshot.
   using Snapshot = std::pair<std::string, uint64_t>;
@@ -590,17 +594,19 @@ private:
 
   class DirSyncPool {
   public:
-    DirSyncPool(int num_threads, const std::string epath, const Peer &m_peer,
-                std::shared_ptr<SnapSyncStat> &sync_stat)
-        : num_threads(num_threads), active(false), queued(0), qlimit(0),
-          epath(epath), m_peer(m_peer), sync_stat(sync_stat) {}
+    DirSyncPool(int num_threads, int qlimit, const std::string epath,
+                const Peer &m_peer, std::shared_ptr<SnapSyncStat> &sync_stat,
+                PeerReplayer *replayer, DirRegistry *registry)
+        : num_threads(num_threads), active(false), queued(0), qlimit(qlimit),
+          epath(epath), m_peer(m_peer), sync_stat(sync_stat),
+          replayer(replayer), registry(registry) {}
     void activate();
     void deactivate();
     bool try_sync(SyncMechanism *task);
-    void sync_anyway(SyncMechanism *task,
-                     LocalSyncStat *local_stat);
-    void sync_direct(SyncMechanism *task,
-                     LocalSyncStat *local_stat);
+    void sync_anyway(SyncMechanism *task, LocalSyncStat *local_stat,
+                     std::queue<FileSyncMechanism *> *local_batch);
+    void sync_direct(SyncMechanism *task, LocalSyncStat *local_stat,
+                     std::queue<FileSyncMechanism *> *local_batch);
     void update_state(int thread_count);
     void dump_stats(Formatter *f) {
       std::scoped_lock lock(mtx);
@@ -609,6 +615,7 @@ private:
     void update_qlimit(int _qlimit);
     void set_low_level(bool _low_level) { low_level = _low_level; }
     bool get_low_level() { return low_level; }
+    void sync_finish();
     friend class PeerReplayer;
 
   private:
@@ -617,6 +624,7 @@ private:
       bool active = false;
       std::thread worker;
       LocalSyncStat local_stat;
+      std::queue <FileSyncMechanism *> local_batch;
       void join() {
         if (worker.joinable()) {
           worker.join();
@@ -638,6 +646,8 @@ private:
     const Peer &m_peer; // just for using dout
     std::shared_ptr<SnapSyncStat>& sync_stat;
     bool low_level = false;
+    PeerReplayer *replayer = nullptr;
+    DirRegistry *registry = nullptr;
   };
 
   bool is_stopping() {
@@ -763,7 +773,8 @@ private:
       const std::string &epath, DirRegistry *registry,
       std::shared_ptr<SnapSyncStat> &sync_stat, const FHandles &fh,
       std::unordered_map<std::string, unsigned int> &change_mask_map,
-      int &change_mask_map_size, LocalSyncStat *local_stat);
+      int &change_mask_map_size, LocalSyncStat *local_stat,
+      std::queue<FileSyncMechanism *> *local_batch);
   int cleanup_remote_entry(const std::string &epath, DirRegistry *registry,
                            const FHandles &fh,
                            std::shared_ptr<SnapSyncStat> &sync_stat,
@@ -828,8 +839,8 @@ private:
   int remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
                      DirRegistry *registry,
                      std::shared_ptr<SnapSyncStat> &sync_stat,
-                     LocalSyncStat *local_stat,
-                     const FHandles &fh);
+                     LocalSyncStat *local_stat, const FHandles &fh,
+                     std::queue<FileSyncMechanism *> *local_batch);
   int copy_to_remote(std::shared_ptr<SyncEntry> &cur_entry,
                      DirRegistry *registry, const FHandles &fh,
                      FileMirrorPool::FileWorker *_file_worker);
@@ -840,8 +851,10 @@ private:
   void _inc_failed_count(const std::string &dir_root);
   void _reset_failed_count(const std::string &dir_root);
   bool should_backoff(DirRegistry* registry, int *retval);
-  void enqueue_file_transfer(FileSyncMechanism *syncm, DirRegistry *registry,
-                             std::shared_ptr<SnapSyncStat> &sync_stat);
+  void
+  enqueue_file_transfer(FileSyncMechanism *syncm, DirRegistry *registry,
+                        std::shared_ptr<SnapSyncStat> &sync_stat,
+                        std::queue<FileSyncMechanism *> *local_batch);
   int64_t get_snap_id_attr(const std::string &dir_root,
                            const std::string &attr);
   int set_snap_id_attr(const std::string &dir_root, const std::string &attr,
@@ -875,8 +888,11 @@ public:
   bool sync_failed_or_canceled() {
     return (registry->failed || registry->canceled);
   }
+  void reset_inode();
   friend class DirSyncMechanism;
+  friend class PeerReplayer;
   LocalSyncStat* local_stat = nullptr;
+  std::queue<FileSyncMechanism *> *local_batch = nullptr;
 
 protected:
   MountRef m_local;
@@ -886,6 +902,7 @@ protected:
   std::shared_ptr<SnapSyncStat> &sync_stat;
   const PeerReplayer::FHandles &fh;
   PeerReplayer *replayer;
+  bool has_reset_inode = false;
   int populate_change_mask(const PeerReplayer::FHandles &fh);
   int populate_current_stat(const PeerReplayer::FHandles &fh);
   int ll_populate_cur_stat_and_cur_inode();

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -20,7 +20,6 @@ namespace mirror {
 class FSMirror;
 class PeerReplayerAdminSocketHook;
 class ServiceDaemon;
-
 struct SnapSyncStat {
   std::atomic <uint64_t> nr_failures = 0; // number of consecutive failures
   boost::optional<monotime> last_failed; // lat failed timestamp
@@ -50,12 +49,13 @@ struct SnapSyncStat {
     uint64_t rfiles;
     uint64_t rbytes;
     std::string diff_base = "";
-    std::atomic<uint64_t> files_in_flight{0};
-    std::atomic<uint64_t> files_data_synced{0};
+    uint64_t files_in_flight = 0;
+    uint64_t files_data_synced = 0;
     std::atomic<uint64_t> files_attr_synced{0};
     std::atomic<uint64_t> files_deleted{0};
     std::atomic<uint64_t> files_skipped{0};
-    std::atomic<uint64_t> file_bytes_synced{0};
+    uint64_t file_bytes_synced = 0;
+    std::atomic<uint64_t> symlink_synced{0};
     std::atomic<uint64_t> dir_created{0};
     std::atomic<uint64_t> dir_deleted{0};
     std::atomic<uint64_t> dir_scanned{0};
@@ -66,12 +66,13 @@ struct SnapSyncStat {
     SyncStat(const SyncStat &other)
         : rfiles(other.rfiles), rbytes(other.rbytes),
           diff_base(other.diff_base),
-          files_in_flight(other.files_in_flight.load()),
-          files_data_synced(other.files_data_synced.load()),
+          files_in_flight(other.files_in_flight),
+          files_data_synced(other.files_data_synced),
           files_attr_synced(other.files_attr_synced.load()),
           files_deleted(other.files_deleted.load()),
           files_skipped(other.files_skipped.load()),
-          file_bytes_synced(other.file_bytes_synced.load()),
+          file_bytes_synced(other.file_bytes_synced),
+          symlink_synced(other.symlink_synced.load()),
           dir_created(other.dir_created.load()),
           dir_deleted(other.dir_deleted.load()),
           dir_scanned(other.dir_scanned.load()),
@@ -82,12 +83,13 @@ struct SnapSyncStat {
         rfiles = other.rfiles;
         rbytes = other.rbytes;
         diff_base = other.diff_base;
-        files_in_flight.store(other.files_in_flight.load());
-        files_data_synced.store(other.files_data_synced.load());
+        files_in_flight = other.files_in_flight;
+        files_data_synced = other.files_data_synced;
         files_attr_synced.store(other.files_attr_synced.load());
         files_deleted.store(other.files_deleted.load());
         files_skipped.store(other.files_skipped.load());
-        file_bytes_synced.store(other.file_bytes_synced.load());
+        file_bytes_synced = other.file_bytes_synced;
+        symlink_synced.store(other.symlink_synced.load());
         dir_created.store(other.dir_created.load());
         dir_deleted.store(other.dir_deleted.load());
         dir_scanned.store(other.dir_scanned.load());
@@ -96,60 +98,52 @@ struct SnapSyncStat {
       }
       return *this;
     }
-    inline void inc_cache_hit() {
-      cache_hit.fetch_add(1, std::memory_order_relaxed);
+    inline void inc_cache_hit(uint64_t val = 1) {
+      cache_hit.fetch_add(val, std::memory_order_relaxed);
     }
-    inline void inc_file_del_count() {
-      files_deleted.fetch_add(1, std::memory_order_relaxed);
+    inline void inc_files_deleted_count(uint64_t val = 1) {
+      files_deleted.fetch_add(val, std::memory_order_relaxed);
     }
-    inline void inc_file_skipped_count() {
-      files_skipped.fetch_add(1, std::memory_order_relaxed);
+    inline void inc_files_skipped_count(uint64_t val = 1) {
+      files_skipped.fetch_add(val, std::memory_order_relaxed);
     }
-    inline void inc_file_data_synced_count(uint64_t file_size) {
-      files_data_synced.fetch_add(1, std::memory_order_relaxed);
-      file_bytes_synced.fetch_add(file_size, std::memory_order_relaxed);
-    }
-    inline void inc_file_attr_synced_count() {
-      files_attr_synced.fetch_add(1, std::memory_order_relaxed);
+    inline void inc_files_attr_synced_count(uint64_t val = 1) {
+      files_attr_synced.fetch_add(val, std::memory_order_relaxed);
     }
     inline void set_diff_base(const std::string &_diff_base) {
       diff_base = _diff_base;
     }
-    inline void inc_file_in_flight_count() {
-      files_in_flight.fetch_add(1, std::memory_order_relaxed);
+    inline void inc_dir_created_count(uint64_t val = 1) {
+      dir_created.fetch_add(val, std::memory_order_relaxed);
     }
-    inline void dec_file_in_flight_count() {
-      files_in_flight.fetch_sub(1, std::memory_order_relaxed);
+    inline void inc_dir_deleted_count(uint64_t val = 1) {
+      dir_deleted.fetch_add(val, std::memory_order_relaxed);
     }
-    inline void inc_dir_created_count() {
-      dir_created.fetch_add(1, std::memory_order_relaxed);
+    inline void inc_dir_scanned_count(uint64_t val = 1) {
+      dir_scanned.fetch_add(val, std::memory_order_relaxed);
     }
-    inline void inc_dir_deleted_count() {
-      dir_deleted.fetch_add(1, std::memory_order_relaxed);
+    inline void inc_dir_attr_synced_count(uint64_t val = 1) {
+      dir_attr_synced.fetch_add(val, std::memory_order_relaxed);
     }
-    inline void inc_dir_scanned_count() {
-      dir_scanned.fetch_add(1, std::memory_order_relaxed);
-    }
-    inline void inc_dir_attr_synced_count() {
-      dir_attr_synced.fetch_add(1, std::memory_order_relaxed);
+    inline void inc_symlink_synced_count() {
+      symlink_synced.fetch_add(1, std::memory_order_relaxed);
     }
     inline void start_timer() { start_time = clock::now(); }
     void dump(Formatter *f) {
       f->dump_unsigned("rfiles", rfiles);
       f->dump_unsigned("rbytes", rbytes);
       f->dump_string("diff_base", diff_base);
-      f->dump_unsigned("files_in_flight",
-                       files_in_flight.load(std::memory_order_relaxed));
-      f->dump_unsigned("files_data_synced",
-                       files_data_synced.load(std::memory_order_relaxed));
+      f->dump_unsigned("files_in_flight", files_in_flight);
+      f->dump_unsigned("files_data_synced", files_data_synced);
       f->dump_unsigned("files_attr_synced",
                        files_attr_synced.load(std::memory_order_relaxed));
       f->dump_unsigned("files_deleted",
                        files_deleted.load(std::memory_order_relaxed));
       f->dump_unsigned("files_skipped",
                        files_skipped.load(std::memory_order_relaxed));
-      f->dump_unsigned("files_bytes_synced",
-                       file_bytes_synced.load(std::memory_order_relaxed));
+      f->dump_unsigned("files_bytes_synced", file_bytes_synced);
+      f->dump_unsigned("symlink_synced",
+                       symlink_synced.load(std::memory_order_relaxed));
       f->dump_unsigned("dir_created",
                        dir_created.load(std::memory_order_relaxed));
       f->dump_unsigned("dir_scanned",
@@ -166,8 +160,7 @@ struct SnapSyncStat {
         double speed = 0;
         std::string syncing_speed = "";
         if (time_elapsed > 0) {
-          speed = (file_bytes_synced.load(std::memory_order_relaxed) * 8.0) /
-                  time_elapsed;
+          speed = (file_bytes_synced * 8.0) / time_elapsed;
           if (speed >= (double)1e9) {
             syncing_speed = std::to_string(speed / (double)1e9) + "Gbps";
           } else if (speed >= (double)1e6) {
@@ -224,6 +217,133 @@ struct SnapSyncStat {
     f->dump_unsigned("snaps_synced", synced_snap_count);
     f->dump_unsigned("snaps_deleted", deleted_snap_count);
     f->dump_unsigned("snaps_renamed", renamed_snap_count);
+  }
+};
+
+struct LocalSyncStat {
+  uint64_t files_attr_synced{0};
+  uint64_t files_deleted{0};
+  uint64_t files_skipped{0};
+  uint64_t dir_created{0};
+  uint64_t dir_deleted{0};
+  uint64_t dir_scanned{0};
+  uint64_t dir_attr_synced{0};
+  uint64_t cache_hit{0};
+  LocalSyncStat() = default;
+  LocalSyncStat(const LocalSyncStat &other)
+      : files_attr_synced(other.files_attr_synced),
+        files_deleted(other.files_deleted), files_skipped(other.files_skipped),
+        dir_created(other.dir_created), dir_deleted(other.dir_deleted),
+        dir_scanned(other.dir_scanned), dir_attr_synced(other.dir_attr_synced),
+        cache_hit(other.cache_hit) {}
+  LocalSyncStat &operator=(const LocalSyncStat &other) {
+    if (this != &other) { // Self-assignment check
+      files_attr_synced = other.files_attr_synced;
+      files_deleted = other.files_deleted;
+      files_skipped = other.files_skipped;
+      dir_created = other.dir_created;
+      dir_deleted = other.dir_deleted;
+      dir_scanned = other.dir_scanned;
+      dir_attr_synced = other.dir_attr_synced;
+      cache_hit = other.cache_hit;
+    }
+    return *this;
+  }
+  inline void flush_cache_hit(SnapSyncStat::SyncStat &sync_stat) {
+    sync_stat.inc_cache_hit(cache_hit);
+    cache_hit = 0;
+  }
+  inline void inc_cache_hit(SnapSyncStat::SyncStat &sync_stat, uint64_t gap) {
+    ++cache_hit;
+    if (cache_hit >= gap) {
+      flush_cache_hit(sync_stat);
+    }
+  }
+  inline void flush_dir_attr_synced_count(SnapSyncStat::SyncStat &sync_stat) {
+    sync_stat.inc_dir_attr_synced_count(dir_attr_synced);
+    dir_attr_synced = 0;
+  }
+  inline void inc_dir_attr_synced_count(SnapSyncStat::SyncStat &sync_stat, uint64_t gap) {
+    ++dir_attr_synced;
+    if (dir_attr_synced >= gap) {
+      flush_dir_attr_synced_count(sync_stat);
+    }
+  }
+  inline void flush_dir_scanned_count(SnapSyncStat::SyncStat &sync_stat) {
+    sync_stat.inc_dir_scanned_count(dir_scanned);
+    dir_scanned = 0;
+  }
+  inline void inc_dir_scanned_count(SnapSyncStat::SyncStat &sync_stat, uint64_t gap) {
+    ++dir_scanned;
+    if (dir_scanned >= gap) {
+      flush_dir_scanned_count(sync_stat);
+    }
+  }
+  inline void flush_dir_deleted_count(SnapSyncStat::SyncStat &sync_stat) {
+    sync_stat.inc_dir_deleted_count(dir_deleted);
+    dir_deleted = 0;
+  }
+  inline void inc_dir_deleted_count(SnapSyncStat::SyncStat &sync_stat, uint64_t gap) {
+    ++dir_deleted;
+    if (dir_deleted >= gap) {
+      flush_dir_deleted_count(sync_stat);
+    }
+  }
+
+  inline void flush_dir_created_count(SnapSyncStat::SyncStat &sync_stat) {
+    sync_stat.inc_dir_created_count(dir_created);
+    dir_created = 0;
+  }
+  inline void inc_dir_created_count(SnapSyncStat::SyncStat &sync_stat, uint64_t gap) {
+    ++dir_created;
+    if (dir_created >= gap) {
+      flush_dir_created_count(sync_stat);
+    }
+  }
+
+  inline void flush_files_attr_synced_count(SnapSyncStat::SyncStat &sync_stat) {
+    sync_stat.inc_files_attr_synced_count(files_attr_synced);
+    files_attr_synced = 0;
+  }
+  inline void inc_files_attr_synced_count(SnapSyncStat::SyncStat &sync_stat, uint64_t gap) {
+    ++files_attr_synced;
+    if (files_attr_synced >= gap) {
+      flush_files_attr_synced_count(sync_stat);
+    }
+  }
+
+  inline void flush_files_skipped_count(SnapSyncStat::SyncStat &sync_stat) {
+    sync_stat.inc_files_skipped_count(files_skipped);
+    files_skipped = 0;
+  }
+  inline void inc_files_skipped_count(SnapSyncStat::SyncStat &sync_stat, uint64_t gap) {
+    ++files_skipped;
+    if (files_skipped >= gap) {
+      flush_files_skipped_count(sync_stat);
+    }
+  }
+
+  inline void flush_files_deleted_count(SnapSyncStat::SyncStat &sync_stat) {
+    sync_stat.inc_files_deleted_count(files_deleted);
+    files_deleted = 0;
+  }
+  inline void inc_files_deleted_count(SnapSyncStat::SyncStat &sync_stat, uint64_t gap) {
+    ++files_deleted;
+    if (files_deleted >= gap) {
+      flush_files_deleted_count(sync_stat);
+    }
+  }
+
+  inline void flush(SnapSyncStat::SyncStat &sync_stat) {
+
+    flush_cache_hit(sync_stat);
+    flush_dir_attr_synced_count(sync_stat);
+    flush_dir_scanned_count(sync_stat);
+    flush_dir_deleted_count(sync_stat);
+    flush_dir_created_count(sync_stat);
+    flush_files_attr_synced_count(sync_stat);
+    flush_files_skipped_count(sync_stat);
+    flush_files_deleted_count(sync_stat);
   }
 };
 
@@ -293,6 +413,7 @@ private:
   bool use_low_level_api = true;
   bool use_at_statx_dont_sync = true;
   unsigned int sync_flags = AT_SYMLINK_NOFOLLOW | AT_STATX_DONT_SYNC;
+  uint64_t stat_flush_counter_gap = 100;
 
       // file descriptor "triplet" for synchronizing a snapshot
   // w/ an added MountRef for accessing "previous" snapshot.
@@ -456,14 +577,17 @@ private:
 
   class DirSyncPool {
   public:
-    DirSyncPool(int num_threads, const std::string epath, const Peer &m_peer)
+    DirSyncPool(int num_threads, const std::string epath, const Peer &m_peer,
+                std::shared_ptr<SnapSyncStat> &sync_stat)
         : num_threads(num_threads), active(false), queued(0), qlimit(0),
-          epath(epath), m_peer(m_peer) {}
+          epath(epath), m_peer(m_peer), sync_stat(sync_stat) {}
     void activate();
     void deactivate();
     bool try_sync(SyncMechanism *task);
-    void sync_anyway(SyncMechanism *task);
-    void sync_direct(SyncMechanism *task);
+    void sync_anyway(SyncMechanism *task,
+                     LocalSyncStat *local_stat);
+    void sync_direct(SyncMechanism *task,
+                     LocalSyncStat *local_stat);
     void update_state(int thread_count);
     void dump_stats(Formatter *f) {
       std::scoped_lock lock(mtx);
@@ -479,6 +603,7 @@ private:
       bool stop_called = true;
       bool active = false;
       std::thread worker;
+      LocalSyncStat local_stat;
       void join() {
         if (worker.joinable()) {
           worker.join();
@@ -498,6 +623,7 @@ private:
     int qlimit;
     std::string epath;
     const Peer &m_peer; // just for using dout
+    std::shared_ptr<SnapSyncStat>& sync_stat;
     bool low_level = false;
   };
 
@@ -584,7 +710,6 @@ private:
   Filesystem m_filesystem;
   Peer m_peer;
   // probably need to be encapsulated when supporting cancelations
-  InodeSharedPtr local_root_inode = nullptr, remote_root_inode = nullptr; 
   std::map<std::string, DirRegistry*> m_registered;
   std::vector<std::string> m_directories, m_deleted_directories;
   std::map<std::string, std::shared_ptr<SnapSyncStat>> m_snap_sync_stats;
@@ -622,13 +747,14 @@ private:
       const std::string &dir_root,
       const std::map<uint64_t, std::pair<std::string, std::string>> &snaps);
   int propagate_deleted_entries(
-      const  std::string &epath, DirRegistry *registry,
+      const std::string &epath, DirRegistry *registry,
       std::shared_ptr<SnapSyncStat> &sync_stat, const FHandles &fh,
       std::unordered_map<std::string, unsigned int> &change_mask_map,
-      int &change_mask_map_size);
+      int &change_mask_map_size, LocalSyncStat *local_stat);
   int cleanup_remote_entry(const std::string &epath, DirRegistry *registry,
                            const FHandles &fh,
                            std::shared_ptr<SnapSyncStat> &sync_stat,
+                           LocalSyncStat *local_stat,
                            int not_dir = -1);
 
   int should_sync_entry(const std::string &epath, const struct ceph_statx &cstx,
@@ -676,12 +802,15 @@ private:
                       const FHandles &fh);
 
   int remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry, const FHandles &fh,
-                   std::shared_ptr<SnapSyncStat> &sync_stat);
+                   std::shared_ptr<SnapSyncStat> &sync_stat,
+                   LocalSyncStat *local_stat);
   int _remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry, const FHandles &fh,
-                    std::shared_ptr<SnapSyncStat> &sync_stat);
+                    std::shared_ptr<SnapSyncStat> &sync_stat,
+                    LocalSyncStat *local_stat);
   int remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
                      DirRegistry *registry,
                      std::shared_ptr<SnapSyncStat> &sync_stat,
+                     LocalSyncStat *local_stat,
                      const FHandles &fh);
   int copy_to_remote(std::shared_ptr<SyncEntry> &cur_entry,
                      DirRegistry *registry, const FHandles &fh,
@@ -729,6 +858,7 @@ public:
     return (registry->failed || registry->canceled);
   }
   friend class DirSyncMechanism;
+  LocalSyncStat* local_stat = nullptr;
 
 protected:
   MountRef m_local;

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -420,15 +420,25 @@ private:
   using Snapshot = std::pair<std::string, uint64_t>;
   using SnapshotPair = std::pair<Snapshot, Snapshot>;
   class DirSyncPool;
+  struct AncestorsLink {
+    std::shared_ptr <AncestorsLink> link = nullptr;
+    InodeSharedPtr inode = nullptr;
+    AncestorsLink() {}
+    AncestorsLink(std::shared_ptr<AncestorsLink> &&_link,
+                  InodeSharedPtr &&_inode)
+        : link(std::move(_link)), inode(std::move(_inode)) {}
+    AncestorsLink(const std::shared_ptr<AncestorsLink> &_link,
+                  const InodeSharedPtr &_inode)
+        : link(_link), inode(_inode) {}
+  };
   struct FHandles {
     struct LL_Fhandle_Info {
-      std::vector<InodeSharedPtr> c_parent_inode = {nullptr};
-      InodeSharedPtr c_inode = nullptr;
-      std::vector<InodeSharedPtr> p_parent_inode = {nullptr};
-      InodeSharedPtr p_inode = nullptr;
-      std::vector<InodeSharedPtr> r_parent_inode = {nullptr};
-      InodeSharedPtr r_inode = nullptr;
-      std::string c_path = "", p_path = "", r_path = "";
+      struct InodeInfo{
+        std::shared_ptr <AncestorsLink> parent = nullptr;
+        InodeSharedPtr inode = nullptr;
+        std::string path = "";
+        bool gap = false;  
+      }c_info, p_info, r_info;
       UserPermRef p_perms;
     }ll_info;
     // open file descriptor on the snap directory for snapshot
@@ -760,9 +770,14 @@ private:
   int should_sync_entry(const std::string &epath, const struct ceph_statx &cstx,
                         const FHandles &fh, bool *need_data_sync, bool *need_attr_sync);
 
-  int ll_open_inode(MountRef mnt, InodeSharedPtr &parent_inode,
+  int ll_open_inode(MountRef mnt, FHandles::LL_Fhandle_Info::InodeInfo &info,
+                    struct ceph_statx &stx, unsigned int want,
+                    UserPermRef perms);
+  int ll_open_inode(MountRef mnt, InodeSharedPtr &parent,
                     const std::string &dir_path, InodeSharedPtr &inode_shared,
                     struct ceph_statx &stx, unsigned int want,
+                    UserPermRef perms);
+  int ll_reduce_gap(MountRef mnt, FHandles::LL_Fhandle_Info::InodeInfo &info,
                     UserPermRef perms);
   int ll_open_dirp(MountRef mnt, InodeSharedPtr &inode, DirUniquePtr &udirp,
                    UserPermRef perms);

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -414,7 +414,9 @@ private:
   bool use_at_statx_dont_sync = true;
   unsigned int sync_flags = AT_SYMLINK_NOFOLLOW | AT_STATX_DONT_SYNC;
   uint64_t stat_flush_counter_gap = 100;
-
+  bool turn_off_assert = false;
+  std::string snap_prefix = "";
+  bool sync_from_remote = false;
       // file descriptor "triplet" for synchronizing a snapshot
   // w/ an added MountRef for accessing "previous" snapshot.
   using Snapshot = std::pair<std::string, uint64_t>;
@@ -582,7 +584,8 @@ private:
       return (change_mask & WASNT_DIR_IN_PREV_SNAPSHOT);
     }
 
-    void rollout(FHandles &parent_fh, const std::string &ename);
+    void rollout(FHandles &parent_fh, const std::string &ename,
+                 PeerReplayer *replayer);
   };
 
   class DirSyncPool {

--- a/src/tools/cephfs_mirror/ServiceDaemon.cc
+++ b/src/tools/cephfs_mirror/ServiceDaemon.cc
@@ -72,12 +72,12 @@ int ServiceDaemon::init() {
   if (id.find(CEPHFS_MIRROR_AUTH_ID_PREFIX) == 0) {
     id = id.substr(CEPHFS_MIRROR_AUTH_ID_PREFIX.size());
   }
-  std::string instance_id = stringify(m_rados->get_instance_id());
+  m_instance_id = stringify(m_rados->get_instance_id());
 
   std::map<std::string, std::string> service_metadata = {{"id", id},
-                                                         {"instance_id", instance_id}};
-  int r = m_rados->service_daemon_register("cephfs-mirror", instance_id,
-                                           service_metadata);
+                                                         {"instance_id", m_instance_id}};
+  int r = m_rados->service_daemon_register("cephfs-mirror", m_instance_id,
+                                            service_metadata);
   if (r < 0) {
     return r;
   }

--- a/src/tools/cephfs_mirror/ServiceDaemon.h
+++ b/src/tools/cephfs_mirror/ServiceDaemon.h
@@ -34,7 +34,10 @@ public:
   void add_or_update_peer_attribute(fs_cluster_id_t fscid, const Peer &peer,
                                     std::string_view key, AttributeValue value);
   void update_peer_info(fs_cluster_id_t fscid, const Peer &peer,
-                          const SnapSyncStatMap &status_map);
+                           const SnapSyncStatMap &status_map);
+  std::string get_instance_id() const {
+    return m_instance_id;
+  }
   const char **get_tracked_conf_keys() const override;
   void handle_conf_change(const ConfigProxy &conf,
                           const std::set<std::string> &changed) override;
@@ -62,6 +65,7 @@ private:
   std::map<fs_cluster_id_t, Filesystem> m_filesystems;
   int status_update_period = 2;
   std::string host_name = "none";
+  std::string m_instance_id;
   std::mutex config_lock;
 
   void start_update_job();

--- a/src/tools/cephfs_mirror/Types.h
+++ b/src/tools/cephfs_mirror/Types.h
@@ -80,6 +80,40 @@ typedef std::shared_ptr<librados::IoCtx> IoCtxRef;
 
 // not a shared_ptr since the type is incomplete
 typedef ceph_mount_info *MountRef;
+typedef UserPerm *UserPermRef;
+struct InodeDeleter {
+  MountRef cmount = nullptr;
+  void operator()(Inode *inode) const {
+    if (cmount && inode) {
+      ceph_ll_forget(cmount, inode, 1);
+    }
+  }
+};
+
+struct DirResultDeleter {
+  MountRef cmount = nullptr;
+  void operator()(struct ceph_dir_result *dirp) const {
+    if (cmount && dirp) {
+      ceph_ll_releasedir(cmount, dirp);
+    }
+  }
+};
+
+struct FhDeleter {
+  MountRef cmount = nullptr;
+  void operator()(struct Fh* fh) const {
+    if (cmount && fh) {
+      ceph_ll_close(cmount, fh);
+    }
+  }
+};
+typedef std::unique_ptr<Inode, InodeDeleter> InodeUniquePtr;
+typedef std::shared_ptr<Inode> InodeSharedPtr;
+typedef Inode *InodeRawPtr;
+typedef struct ceph_dir_result* DirRawPtr;
+typedef struct Fh* FhRawPtr;
+typedef std::unique_ptr<ceph_dir_result, DirResultDeleter> DirUniquePtr;
+typedef std::unique_ptr<struct Fh, FhDeleter> FhUniquePtr;
 
 using clock = ceph::coarse_mono_clock;
 using monotime = ceph::coarse_mono_time;


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
